### PR TITLE
fix: upgrade the fkirc/skip-duplicate-actions version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Detect No-op Changes
         id: noop
-        uses: fkirc/skip-duplicate-actions@v3.3.0
+        uses: fkirc/skip-duplicate-actions@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           do_not_skip: '["workflow_dispatch", "schedule", "push"]'


### PR DESCRIPTION
fix: upgrade the fkirc/skip-duplicate-actions version to fix Go-Lint/detect-noop failure.


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Go-Lint/detect-noop (pull_request failed.
It is a known (and fixed) issue, which happens after a PR is resent after being closed; see https://github.com/fkirc/skip-duplicate-actions/issues/127 and https://github.com/fkirc/skip-duplicate-actions/pull/178 for more information.

We should be able to fix it by bumping the version of the skip-duplicate-actions module (3.3.0 is currently in use).