### PR TITLE
fix: remove uniqueItems marker

### DIFF
--- a/api/v1alpha1/endpointsliceexport_types.go
+++ b/api/v1alpha1/endpointsliceexport_types.go
@@ -19,7 +19,6 @@ type Endpoint struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems:1
 	// +kubebuilder:validation:MaxItems:100
-	// +kubebuilder:validation:UniqueItems:=true
 	Addresses []string `json:"addresses"`
 }
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -12,7 +12,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/discovery/v1"
+	"k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/config/crd/bases/networking.fleet.azure.com_endpointsliceexports.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_endpointsliceexports.yaml
@@ -93,7 +93,6 @@ spec:
                       items:
                         type: string
                       type: array
-                      uniqueItems: true
                   required:
                   - addresses
                   type: object


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind api-change

**What this PR does / why we need it**:

This PR removes the uniqueItems marker from API definitions: even though kubebuilder supports it and will generate OpenAPI spec correctly, at this moment [Kubernetes will reject any CRD with this field set to true](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation).

**Which issue(s) this PR fixes**:

N/A

**Requirements**:

- [*] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [*] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [N/A] includes documentation
- [N/A] adds unit tests

### How has this code been tested

N/A

### Special notes for your reviewer

