### PR TITLE
feat: add FromMetaObjects func + UpdateFromMetaObject method

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -6,7 +6,7 @@ Licensed under the MIT license.
 package v1alpha1
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -40,7 +40,7 @@ type ExportedObjectReference struct {
 }
 
 // FromMetaObjects builds a new ExportedObjectReference using TypeMeta and ObjectMeta fields from an object.
-func FromMetaObjects(clusterID string, typeMeta v1.TypeMeta, objMeta v1.ObjectMeta) ExportedObjectReference {
+func FromMetaObjects(clusterID string, typeMeta metav1.TypeMeta, objMeta metav1.ObjectMeta) ExportedObjectReference {
 	return ExportedObjectReference{
 		ClusterID:       clusterID,
 		APIVersion:      typeMeta.APIVersion,
@@ -56,7 +56,7 @@ func FromMetaObjects(clusterID string, typeMeta v1.TypeMeta, objMeta v1.ObjectMe
 // UpdateFromMetaObject updates an existing ExportedObjectReference using ObjectMeta fields from the
 // referenced object. Note that most fields in an ExportedObjectReference should be immutable after creation,
 // and this method updates only the mutable fields.
-func (e *ExportedObjectReference) UpdateFromMetaObject(objMeta v1.ObjectMeta) {
+func (e *ExportedObjectReference) UpdateFromMetaObject(objMeta metav1.ObjectMeta) {
 	e.ResourceVersion = objMeta.ResourceVersion
 	e.Generation = objMeta.Generation
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds a `FromMetaObjects` func, and a `UpdateFromMetaObject` method to `*ExportedObjectReference` , or easier ExportedObjectReference setup/update.

**Which issue(s) this PR fixes**:

N/A

**Requirements**:

- [*] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [*] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [N/A] includes documentation
- [N/A] adds unit tests

### How has this code been tested

N/A

### Special notes for your reviewer

