### PR TITLE
fix: set up Scheme field for MCS reconciler

### DIFF
--- a/cmd/mcs-controller-manager/main.go
+++ b/cmd/mcs-controller-manager/main.go
@@ -79,6 +79,7 @@ func main() {
 	//+kubebuilder:scaffold:builder
 	r := &multiclusterservice.Reconciler{
 		Client:               mgr.GetClient(),
+		Scheme:               mgr.GetScheme(),
 		FleetSystemNamespace: *fleetSystemNamespace,
 	}
 	if err := r.SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes a bug in the MCS controller manager, which does not set up the `Scheme` field for MCS reconciler. This will lead to a crash when MCS resources are being reconciled.

**Which issue(s) this PR fixes**:

N/A

**Requirements**:

- [x] run `make reviewable` for basic local test
- [x] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [N/A] includes documentation
- [N/A] adds unit tests

### How has this code been tested

N/A

### Special notes for your reviewer
