### PR TITLE
fix: unexport test related variables and const

### DIFF
--- a/pkg/controllers/member/endpointsliceexport/controller_integration_test.go
+++ b/pkg/controllers/member/endpointsliceexport/controller_integration_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	MemberClusterID = "bravelion"
+	memberClusterID = "bravelion"
 
 	eventuallyTimeout    = time.Second * 10
 	eventuallyInterval   = time.Millisecond * 250
@@ -52,7 +52,7 @@ var _ = Describe("endpointsliceexport controller", func() {
 						},
 					},
 					EndpointSliceReference: fleetnetv1alpha1.ExportedObjectReference{
-						ClusterID:       MemberClusterID,
+						ClusterID:       memberClusterID,
 						Kind:            "EndpointSlice",
 						Namespace:       memberUserNS,
 						Name:            endpointSliceName,
@@ -62,7 +62,7 @@ var _ = Describe("endpointsliceexport controller", func() {
 					},
 				},
 			}
-			Expect(HubClient.Create(ctx, danglingEndpointSliceExport)).Should(Succeed())
+			Expect(hubClient.Create(ctx, danglingEndpointSliceExport)).Should(Succeed())
 		})
 
 		It("should remove dangling endpointsliceexport", func() {
@@ -71,7 +71,7 @@ var _ = Describe("endpointsliceexport controller", func() {
 				Name:      endpointSliceExportName,
 			}
 			Eventually(func() bool {
-				return errors.IsNotFound(HubClient.Get(ctx, endpointSliceExportKey, danglingEndpointSliceExport))
+				return errors.IsNotFound(hubClient.Get(ctx, endpointSliceExportKey, danglingEndpointSliceExport))
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 		})
 	})
@@ -98,7 +98,7 @@ var _ = Describe("endpointsliceexport controller", func() {
 					},
 				},
 			}
-			Expect(MemberClient.Create(ctx, unlinkedEndpointSlice)).Should(Succeed())
+			Expect(memberClient.Create(ctx, unlinkedEndpointSlice)).Should(Succeed())
 
 			unlinkedEndpointSliceExport = &fleetnetv1alpha1.EndpointSliceExport{
 				ObjectMeta: metav1.ObjectMeta{
@@ -118,7 +118,7 @@ var _ = Describe("endpointsliceexport controller", func() {
 						},
 					},
 					EndpointSliceReference: fleetnetv1alpha1.ExportedObjectReference{
-						ClusterID:       MemberClusterID,
+						ClusterID:       memberClusterID,
 						Kind:            "EndpointSlice",
 						Namespace:       memberUserNS,
 						Name:            endpointSliceName,
@@ -128,11 +128,11 @@ var _ = Describe("endpointsliceexport controller", func() {
 					},
 				},
 			}
-			Expect(HubClient.Create(ctx, unlinkedEndpointSliceExport)).Should(Succeed())
+			Expect(hubClient.Create(ctx, unlinkedEndpointSliceExport)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(MemberClient.Delete(ctx, unlinkedEndpointSlice)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, unlinkedEndpointSlice)).Should(Succeed())
 		})
 
 		It("should remove unlinked endpointsliceexport", func() {
@@ -141,7 +141,7 @@ var _ = Describe("endpointsliceexport controller", func() {
 				Name:      endpointSliceExportName,
 			}
 			Eventually(func() bool {
-				return errors.IsNotFound(HubClient.Get(ctx, endpointSliceExportKey, unlinkedEndpointSliceExport))
+				return errors.IsNotFound(hubClient.Get(ctx, endpointSliceExportKey, unlinkedEndpointSliceExport))
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 		})
 	})
@@ -171,7 +171,7 @@ var _ = Describe("endpointsliceexport controller", func() {
 					},
 				},
 			}
-			Expect(MemberClient.Create(ctx, linkedEndpointSlice)).Should(Succeed())
+			Expect(memberClient.Create(ctx, linkedEndpointSlice)).Should(Succeed())
 
 			linkedEndpointSliceExport = &fleetnetv1alpha1.EndpointSliceExport{
 				ObjectMeta: metav1.ObjectMeta{
@@ -191,7 +191,7 @@ var _ = Describe("endpointsliceexport controller", func() {
 						},
 					},
 					EndpointSliceReference: fleetnetv1alpha1.ExportedObjectReference{
-						ClusterID:       MemberClusterID,
+						ClusterID:       memberClusterID,
 						Kind:            "EndpointSlice",
 						Namespace:       memberUserNS,
 						Name:            endpointSliceName,
@@ -201,12 +201,12 @@ var _ = Describe("endpointsliceexport controller", func() {
 					},
 				},
 			}
-			Expect(HubClient.Create(ctx, linkedEndpointSliceExport)).Should(Succeed())
+			Expect(hubClient.Create(ctx, linkedEndpointSliceExport)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(HubClient.Delete(ctx, linkedEndpointSliceExport)).Should(Succeed())
-			Expect(MemberClient.Delete(ctx, linkedEndpointSlice)).Should(Succeed())
+			Expect(hubClient.Delete(ctx, linkedEndpointSliceExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, linkedEndpointSlice)).Should(Succeed())
 		})
 
 		It("should keep linked endpointsliceexport", func() {
@@ -215,7 +215,7 @@ var _ = Describe("endpointsliceexport controller", func() {
 					Namespace: hubNSForMember,
 					Name:      endpointSliceExportName,
 				}
-				return HubClient.Get(ctx, endpointSliceExportKey, linkedEndpointSliceExport)
+				return hubClient.Get(ctx, endpointSliceExportKey, linkedEndpointSliceExport)
 			}, consistentlyDuration, ConsistentlyInterval).Should(BeNil())
 		})
 	})

--- a/pkg/controllers/member/endpointsliceexport/suite_test.go
+++ b/pkg/controllers/member/endpointsliceexport/suite_test.go
@@ -27,8 +27,8 @@ import (
 var (
 	memberTestEnv *envtest.Environment
 	hubTestEnv    *envtest.Environment
-	MemberClient  client.Client
-	HubClient     client.Client
+	memberClient  client.Client
+	hubClient     client.Client
 	ctx           context.Context
 	cancel        context.CancelFunc
 )
@@ -41,14 +41,14 @@ func setUpResources() {
 			Name: memberUserNS,
 		},
 	}
-	Expect(MemberClient.Create(ctx, &memberNS)).Should(Succeed())
+	Expect(memberClient.Create(ctx, &memberNS)).Should(Succeed())
 
 	hubNS := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: hubNSForMember,
 		},
 	}
-	Expect(HubClient.Create(ctx, &hubNS)).Should(Succeed())
+	Expect(hubClient.Create(ctx, &hubNS)).Should(Succeed())
 }
 
 func TestAPIs(t *testing.T) {
@@ -85,12 +85,12 @@ var _ = BeforeSuite(func() {
 	Expect(fleetnetv1alpha1.AddToScheme(scheme.Scheme)).Should(Succeed())
 
 	// Set up clients for member and hub clusters.
-	MemberClient, err = client.New(memberCfg, client.Options{Scheme: scheme.Scheme})
+	memberClient, err = client.New(memberCfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(MemberClient).NotTo(BeNil())
-	HubClient, err = client.New(hubCfg, client.Options{Scheme: scheme.Scheme})
+	Expect(memberClient).NotTo(BeNil())
+	hubClient, err = client.New(hubCfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(HubClient).NotTo(BeNil())
+	Expect(hubClient).NotTo(BeNil())
 
 	// Set up resources.
 	setUpResources()
@@ -103,8 +103,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&Reconciler{
-		MemberClient: MemberClient,
-		HubClient:    HubClient,
+		MemberClient: memberClient,
+		HubClient:    hubClient,
 	}).SetupWithManager(ctrlMgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/controllers/member/internalserviceexport/controller_integration_test.go
+++ b/pkg/controllers/member/internalserviceexport/controller_integration_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	MemberClusterID = "bravelion"
+	memberClusterID = "bravelion"
 	svcPort         = 80
 
 	eventuallyTimeout  = time.Second * 10
@@ -45,7 +45,7 @@ var _ = Describe("internalsvcexport controller", func() {
 						},
 					},
 					ServiceReference: fleetnetv1alpha1.ExportedObjectReference{
-						ClusterID:       MemberClusterID,
+						ClusterID:       memberClusterID,
 						Kind:            "Service",
 						Namespace:       memberUserNS,
 						Name:            svcName,
@@ -55,7 +55,7 @@ var _ = Describe("internalsvcexport controller", func() {
 					},
 				},
 			}
-			Expect(HubClient.Create(ctx, danglingInternalSvcExport)).Should(Succeed())
+			Expect(hubClient.Create(ctx, danglingInternalSvcExport)).Should(Succeed())
 		})
 
 		It("should remove dangling internalsvcexport", func() {
@@ -64,7 +64,7 @@ var _ = Describe("internalsvcexport controller", func() {
 				Name:      fmt.Sprintf("%s-%s", memberUserNS, svcName),
 			}
 			Eventually(func() bool {
-				return errors.IsNotFound(HubClient.Get(ctx, internalSvcExportKey, danglingInternalSvcExport))
+				return errors.IsNotFound(hubClient.Get(ctx, internalSvcExportKey, danglingInternalSvcExport))
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 		})
 	})
@@ -80,7 +80,7 @@ var _ = Describe("internalsvcexport controller", func() {
 					Name:      svcName,
 				},
 			}
-			Expect(MemberClient.Create(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svcExport)).Should(Succeed())
 
 			internalSvcExport = &fleetnetv1alpha1.InternalServiceExport{
 				ObjectMeta: metav1.ObjectMeta{
@@ -94,7 +94,7 @@ var _ = Describe("internalsvcexport controller", func() {
 						},
 					},
 					ServiceReference: fleetnetv1alpha1.ExportedObjectReference{
-						ClusterID:       MemberClusterID,
+						ClusterID:       memberClusterID,
 						Kind:            "Service",
 						Namespace:       memberUserNS,
 						Name:            svcName,
@@ -104,18 +104,18 @@ var _ = Describe("internalsvcexport controller", func() {
 					},
 				},
 			}
-			Expect(HubClient.Create(ctx, internalSvcExport)).Should(Succeed())
+			Expect(hubClient.Create(ctx, internalSvcExport)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(HubClient.Delete(ctx, internalSvcExport)).Should(Succeed())
-			Expect(MemberClient.Delete(ctx, svcExport)).Should(Succeed())
+			Expect(hubClient.Delete(ctx, internalSvcExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svcExport)).Should(Succeed())
 		})
 
 		It("should not report back any conflict resolution result", func() {
 			svcExportKey := types.NamespacedName{Namespace: memberUserNS, Name: svcName}
 			Eventually(func() []metav1.Condition {
-				Expect(MemberClient.Get(ctx, svcExportKey, svcExport)).Should(Succeed())
+				Expect(memberClient.Get(ctx, svcExportKey, svcExport)).Should(Succeed())
 				return svcExport.Status.Conditions
 			}).Should(BeNil())
 		})
@@ -132,7 +132,7 @@ var _ = Describe("internalsvcexport controller", func() {
 					Name:      svcName,
 				},
 			}
-			Expect(MemberClient.Create(ctx, unconflictedSvcExport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, unconflictedSvcExport)).Should(Succeed())
 
 			unconflictedInternalSvcExport = &fleetnetv1alpha1.InternalServiceExport{
 				ObjectMeta: metav1.ObjectMeta{
@@ -146,7 +146,7 @@ var _ = Describe("internalsvcexport controller", func() {
 						},
 					},
 					ServiceReference: fleetnetv1alpha1.ExportedObjectReference{
-						ClusterID:       MemberClusterID,
+						ClusterID:       memberClusterID,
 						Kind:            "Service",
 						Namespace:       memberUserNS,
 						Name:            svcName,
@@ -156,25 +156,25 @@ var _ = Describe("internalsvcexport controller", func() {
 					},
 				},
 			}
-			Expect(HubClient.Create(ctx, unconflictedInternalSvcExport)).Should(Succeed())
+			Expect(hubClient.Create(ctx, unconflictedInternalSvcExport)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(HubClient.Delete(ctx, unconflictedInternalSvcExport)).Should(Succeed())
-			Expect(MemberClient.Delete(ctx, unconflictedSvcExport)).Should(Succeed())
+			Expect(hubClient.Delete(ctx, unconflictedInternalSvcExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, unconflictedSvcExport)).Should(Succeed())
 		})
 
 		It("should report back conflict condition (no conflict found)", func() {
 			// Add a no conflict condition
 			meta.SetStatusCondition(&unconflictedInternalSvcExport.Status.Conditions,
 				unconflictedServiceExportConflictCondition(memberUserNS, svcName))
-			Expect(HubClient.Status().Update(ctx, unconflictedInternalSvcExport)).Should(Succeed())
+			Expect(hubClient.Status().Update(ctx, unconflictedInternalSvcExport)).Should(Succeed())
 
 			unconflictedSvcExportKey := types.NamespacedName{Namespace: memberUserNS, Name: svcName}
 			// TO-DO (chenyu1): newer gomega versions offer BeComparableTo function, which automatically
 			// calls cmp package for diffs.
 			Eventually(func() string {
-				Expect(MemberClient.Get(ctx, unconflictedSvcExportKey, unconflictedSvcExport)).Should(Succeed())
+				Expect(memberClient.Get(ctx, unconflictedSvcExportKey, unconflictedSvcExport)).Should(Succeed())
 				return cmp.Diff(
 					unconflictedSvcExport.Status.Conditions,
 					[]metav1.Condition{
@@ -196,7 +196,7 @@ var _ = Describe("internalsvcexport controller", func() {
 					Name:      svcName,
 				},
 			}
-			Expect(MemberClient.Create(ctx, conflictedSvcExport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, conflictedSvcExport)).Should(Succeed())
 
 			conflictedInternalSvcExport = &fleetnetv1alpha1.InternalServiceExport{
 				ObjectMeta: metav1.ObjectMeta{
@@ -210,7 +210,7 @@ var _ = Describe("internalsvcexport controller", func() {
 						},
 					},
 					ServiceReference: fleetnetv1alpha1.ExportedObjectReference{
-						ClusterID:       MemberClusterID,
+						ClusterID:       memberClusterID,
 						Kind:            "Service",
 						Namespace:       memberUserNS,
 						Name:            svcName,
@@ -220,25 +220,25 @@ var _ = Describe("internalsvcexport controller", func() {
 					},
 				},
 			}
-			Expect(HubClient.Create(ctx, conflictedInternalSvcExport)).Should(Succeed())
+			Expect(hubClient.Create(ctx, conflictedInternalSvcExport)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(HubClient.Delete(ctx, conflictedInternalSvcExport)).Should(Succeed())
-			Expect(MemberClient.Delete(ctx, conflictedSvcExport)).Should(Succeed())
+			Expect(hubClient.Delete(ctx, conflictedInternalSvcExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, conflictedSvcExport)).Should(Succeed())
 		})
 
 		It("should report back conflict condition (conflict found)", func() {
 			// Add a no conflict condition
 			meta.SetStatusCondition(&conflictedInternalSvcExport.Status.Conditions,
 				conflictedServiceExportConflictCondition(memberUserNS, svcName))
-			Expect(HubClient.Status().Update(ctx, conflictedInternalSvcExport)).Should(Succeed())
+			Expect(hubClient.Status().Update(ctx, conflictedInternalSvcExport)).Should(Succeed())
 
 			conflictedSvcExportKey := types.NamespacedName{Namespace: memberUserNS, Name: svcName}
 			// TO-DO (chenyu1): newer gomega versions offer BeComparableTo function, which automatically
 			// calls cmp package for diffs.
 			Eventually(func() string {
-				Expect(MemberClient.Get(ctx, conflictedSvcExportKey, conflictedSvcExport)).Should(Succeed())
+				Expect(memberClient.Get(ctx, conflictedSvcExportKey, conflictedSvcExport)).Should(Succeed())
 				return cmp.Diff(
 					conflictedSvcExport.Status.Conditions,
 					[]metav1.Condition{

--- a/pkg/controllers/member/internalserviceexport/suite_test.go
+++ b/pkg/controllers/member/internalserviceexport/suite_test.go
@@ -29,8 +29,8 @@ import (
 var (
 	memberTestEnv *envtest.Environment
 	hubTestEnv    *envtest.Environment
-	MemberClient  client.Client
-	HubClient     client.Client
+	memberClient  client.Client
+	hubClient     client.Client
 	ctx           context.Context
 	cancel        context.CancelFunc
 )
@@ -43,14 +43,14 @@ func setUpResources() {
 			Name: memberUserNS,
 		},
 	}
-	Expect(MemberClient.Create(ctx, &memberNS)).Should(Succeed())
+	Expect(memberClient.Create(ctx, &memberNS)).Should(Succeed())
 
 	hubNS := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: hubNSForMember,
 		},
 	}
-	Expect(HubClient.Create(ctx, &hubNS)).Should(Succeed())
+	Expect(hubClient.Create(ctx, &hubNS)).Should(Succeed())
 }
 
 func TestAPIs(t *testing.T) {
@@ -87,12 +87,12 @@ var _ = BeforeSuite(func() {
 	Expect(fleetnetv1alpha1.AddToScheme(scheme.Scheme)).Should(Succeed())
 
 	// Set up clients for member and hub clusters.
-	MemberClient, err = client.New(memberCfg, client.Options{Scheme: scheme.Scheme})
+	memberClient, err = client.New(memberCfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(MemberClient).NotTo(BeNil())
-	HubClient, err = client.New(hubCfg, client.Options{Scheme: scheme.Scheme})
+	Expect(memberClient).NotTo(BeNil())
+	hubClient, err = client.New(hubCfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(HubClient).NotTo(BeNil())
+	Expect(hubClient).NotTo(BeNil())
 
 	// Set up resources.
 	setUpResources()
@@ -110,8 +110,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&Reconciler{
-		MemberClient: MemberClient,
-		HubClient:    HubClient,
+		MemberClient: memberClient,
+		HubClient:    hubClient,
 	}).SetupWithManager(ctrlMgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/controllers/member/internalserviceimport/controller_integration_test.go
+++ b/pkg/controllers/member/internalserviceimport/controller_integration_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Test InternalServiceImport Controller", func() {
 					},
 				},
 			}
-			Expect(HubClient.Create(ctx, danglingInternalServiceImport)).Should(Succeed())
+			Expect(hubClient.Create(ctx, danglingInternalServiceImport)).Should(Succeed())
 		})
 
 		It("Should remove dangling internalServiceImport", func() {
@@ -47,7 +47,7 @@ var _ = Describe("Test InternalServiceImport Controller", func() {
 				Name:      testName,
 			}
 			Eventually(func() bool {
-				return errors.IsNotFound(HubClient.Get(ctx, internalServiceImportKey, danglingInternalServiceImport))
+				return errors.IsNotFound(hubClient.Get(ctx, internalServiceImportKey, danglingInternalServiceImport))
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
@@ -64,7 +64,7 @@ var _ = Describe("Test InternalServiceImport Controller", func() {
 					Name:      testName,
 				},
 			}
-			Expect(MemberClient.Create(ctx, serviceImport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, serviceImport)).Should(Succeed())
 
 			By("Creating internalServiceImport")
 			internalServiceImport = &fleetnetv1alpha1.InternalServiceImport{
@@ -102,15 +102,15 @@ var _ = Describe("Test InternalServiceImport Controller", func() {
 					},
 				},
 			}
-			Expect(HubClient.Create(ctx, internalServiceImport)).Should(Succeed())
-			Expect(HubClient.Status().Update(ctx, internalServiceImport)).Should(Succeed())
+			Expect(hubClient.Create(ctx, internalServiceImport)).Should(Succeed())
+			Expect(hubClient.Status().Update(ctx, internalServiceImport)).Should(Succeed())
 		})
 		AfterEach(func() {
 			By("Deleting internalServiceImport")
-			Expect(HubClient.Delete(ctx, internalServiceImport)).Should(Succeed())
+			Expect(hubClient.Delete(ctx, internalServiceImport)).Should(Succeed())
 
 			By("Deleting serviceImport")
-			Expect(MemberClient.Delete(ctx, serviceImport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, serviceImport)).Should(Succeed())
 		})
 
 		It("Reporting back serviceImport status from the fleet to the member cluster", func() {
@@ -120,7 +120,7 @@ var _ = Describe("Test InternalServiceImport Controller", func() {
 				Name:      testName,
 			}
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, serviceImportKey, serviceImport); err != nil {
+				if err := memberClient.Get(ctx, serviceImportKey, serviceImport); err != nil {
 					return false
 				}
 				return cmp.Equal(internalServiceImport.Status, serviceImport.Status)
@@ -128,11 +128,11 @@ var _ = Describe("Test InternalServiceImport Controller", func() {
 
 			By("Updating internalServiceImport status")
 			internalServiceImport.Status.Type = fleetnetv1alpha1.Headless
-			Expect(HubClient.Status().Update(ctx, internalServiceImport)).Should(Succeed())
+			Expect(hubClient.Status().Update(ctx, internalServiceImport)).Should(Succeed())
 
 			By("Checking serviceImport status")
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, serviceImportKey, serviceImport); err != nil {
+				if err := memberClient.Get(ctx, serviceImportKey, serviceImport); err != nil {
 					return false
 				}
 				return cmp.Equal(internalServiceImport.Status, serviceImport.Status)

--- a/pkg/controllers/member/internalserviceimport/suite_test.go
+++ b/pkg/controllers/member/internalserviceimport/suite_test.go
@@ -29,8 +29,8 @@ var (
 	memberConfig  *rest.Config
 	hubConfig     *rest.Config
 	mgr           manager.Manager
-	MemberClient  client.Client
-	HubClient     client.Client
+	memberClient  client.Client
+	hubClient     client.Client
 	memberTestEnv *envtest.Environment
 	hubTestEnv    *envtest.Environment
 	ctx           context.Context
@@ -78,14 +78,14 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:scheme
 	By("construct the member k8s client")
-	MemberClient, err = client.New(memberConfig, client.Options{Scheme: scheme.Scheme})
+	memberClient, err = client.New(memberConfig, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(MemberClient).NotTo(BeNil())
+	Expect(memberClient).NotTo(BeNil())
 
 	By("construct the hub k8s client")
-	HubClient, err = client.New(hubConfig, client.Options{Scheme: scheme.Scheme})
+	hubClient, err = client.New(hubConfig, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(HubClient).NotTo(BeNil())
+	Expect(hubClient).NotTo(BeNil())
 
 	By("Create member namespace")
 	ns := corev1.Namespace{
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 			Name: testNamespace,
 		},
 	}
-	Expect(MemberClient.Create(ctx, &ns)).Should(Succeed())
+	Expect(memberClient.Create(ctx, &ns)).Should(Succeed())
 
 	By("Create fleet namespace")
 	ns = corev1.Namespace{
@@ -101,7 +101,7 @@ var _ = BeforeSuite(func() {
 			Name: testFleetNamespace,
 		},
 	}
-	Expect(HubClient.Create(ctx, &ns)).Should(Succeed())
+	Expect(hubClient.Create(ctx, &ns)).Should(Succeed())
 
 	By("starting the controller manager")
 	klog.InitFlags(flag.CommandLine)
@@ -116,8 +116,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&Reconciler{
-		MemberClient: MemberClient,
-		HubClient:    HubClient,
+		MemberClient: memberClient,
+		HubClient:    hubClient,
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/controllers/member/serviceexport/controller_integration_test.go
+++ b/pkg/controllers/member/serviceexport/controller_integration_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	MemberClusterID  = "bravelion"
+	memberClusterID  = "bravelion"
 	svcPortName      = "port1"
 	svcPort          = 80
 	targetPort       = 8080
@@ -112,16 +112,16 @@ var _ = Describe("serviceexport controller", func() {
 
 		BeforeEach(func() {
 			svcExport = notYetFulfilledServiceExport()
-			Expect(MemberClient.Create(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svcExport)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(MemberClient.Delete(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svcExport)).Should(Succeed())
 		})
 
 		It("should mark the service export as invalid + should not export service", func() {
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
 					return false
 				}
 
@@ -136,7 +136,7 @@ var _ = Describe("serviceexport controller", func() {
 
 			Consistently(func() bool {
 				internalSvcExportList := &fleetnetv1alpha1.InternalServiceExportList{}
-				if err := HubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
+				if err := hubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
 					return false
 				}
 
@@ -151,17 +151,17 @@ var _ = Describe("serviceexport controller", func() {
 
 		BeforeEach(func() {
 			svc = clusterIPService()
-			Expect(MemberClient.Create(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svc)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(MemberClient.Delete(ctx, svcExport)).Should(Succeed())
-			Expect(MemberClient.Delete(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svc)).Should(Succeed())
 
 			// Confirm that the Service has been unexported; this helps make the tests less flaky.
 			Eventually(func() bool {
 				internalSvcExportList := &fleetnetv1alpha1.InternalServiceExportList{}
-				if err := HubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
+				if err := hubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
 					return false
 				}
 
@@ -169,7 +169,7 @@ var _ = Describe("serviceexport controller", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err == nil || !errors.IsNotFound(err) {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err == nil || !errors.IsNotFound(err) {
 					return false
 				}
 				return true
@@ -178,10 +178,10 @@ var _ = Describe("serviceexport controller", func() {
 
 		It("should mark the service export as valid + should export the service", func() {
 			svcExport = notYetFulfilledServiceExport()
-			Expect(MemberClient.Create(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svcExport)).Should(Succeed())
 
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
 					return false
 				}
 
@@ -202,7 +202,7 @@ var _ = Describe("serviceexport controller", func() {
 
 			Eventually(func() bool {
 				internalSvcExport := &fleetnetv1alpha1.InternalServiceExport{}
-				if err := HubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
+				if err := hubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
 					return false
 				}
 
@@ -215,7 +215,7 @@ var _ = Describe("serviceexport controller", func() {
 						},
 					},
 					ServiceReference: fleetnetv1alpha1.FromMetaObjects(
-						MemberClusterID,
+						memberClusterID,
 						svc.TypeMeta,
 						svc.ObjectMeta,
 					),
@@ -231,17 +231,17 @@ var _ = Describe("serviceexport controller", func() {
 
 		BeforeEach(func() {
 			svcExport = notYetFulfilledServiceExport()
-			Expect(MemberClient.Create(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svcExport)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(MemberClient.Delete(ctx, svcExport)).Should(Succeed())
-			Expect(MemberClient.Delete(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svc)).Should(Succeed())
 
 			// Confirm that the Service has been unexported; this helps make the tests less flaky.
 			Eventually(func() bool {
 				internalSvcExportList := &fleetnetv1alpha1.InternalServiceExportList{}
-				if err := HubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
+				if err := hubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
 					return false
 				}
 
@@ -249,7 +249,7 @@ var _ = Describe("serviceexport controller", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err == nil || !errors.IsNotFound(err) {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err == nil || !errors.IsNotFound(err) {
 					return false
 				}
 				return true
@@ -258,10 +258,10 @@ var _ = Describe("serviceexport controller", func() {
 
 		It("should mark the service export as valid + should export the service", func() {
 			svc = clusterIPService()
-			Expect(MemberClient.Create(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svc)).Should(Succeed())
 
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
 					return false
 				}
 
@@ -282,7 +282,7 @@ var _ = Describe("serviceexport controller", func() {
 
 			Eventually(func() bool {
 				internalSvcExport := &fleetnetv1alpha1.InternalServiceExport{}
-				if err := HubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
+				if err := hubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
 					return false
 				}
 
@@ -295,7 +295,7 @@ var _ = Describe("serviceexport controller", func() {
 						},
 					},
 					ServiceReference: fleetnetv1alpha1.FromMetaObjects(
-						MemberClusterID,
+						memberClusterID,
 						svc.TypeMeta,
 						svc.ObjectMeta,
 					),
@@ -314,20 +314,20 @@ var _ = Describe("serviceexport controller", func() {
 
 		BeforeEach(func() {
 			svcExport = notYetFulfilledServiceExport()
-			Expect(MemberClient.Create(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svcExport)).Should(Succeed())
 
 			svc = clusterIPService()
-			Expect(MemberClient.Create(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svc)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(MemberClient.Delete(ctx, svcExport)).Should(Succeed())
-			Expect(MemberClient.Delete(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svc)).Should(Succeed())
 
 			// Confirm that the Service has been unexported; this helps make the tests less flaky.
 			Eventually(func() bool {
 				internalSvcExportList := &fleetnetv1alpha1.InternalServiceExportList{}
-				if err := HubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
+				if err := hubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
 					return false
 				}
 
@@ -335,7 +335,7 @@ var _ = Describe("serviceexport controller", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err == nil || !errors.IsNotFound(err) {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err == nil || !errors.IsNotFound(err) {
 					return false
 				}
 				return true
@@ -345,7 +345,7 @@ var _ = Describe("serviceexport controller", func() {
 		It("should update the exported service", func() {
 			By("confirm that the service has been exported")
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
 					return false
 				}
 
@@ -366,7 +366,7 @@ var _ = Describe("serviceexport controller", func() {
 
 			Eventually(func() bool {
 				internalSvcExport := &fleetnetv1alpha1.InternalServiceExport{}
-				if err := HubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
+				if err := hubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
 					return false
 				}
 
@@ -379,7 +379,7 @@ var _ = Describe("serviceexport controller", func() {
 						},
 					},
 					ServiceReference: fleetnetv1alpha1.FromMetaObjects(
-						MemberClusterID,
+						memberClusterID,
 						svc.TypeMeta,
 						svc.ObjectMeta,
 					),
@@ -388,7 +388,7 @@ var _ = Describe("serviceexport controller", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 
 			By("update the service")
-			Expect(MemberClient.Get(ctx, svcOrSvcExportKey, svc)).Should(Succeed())
+			Expect(memberClient.Get(ctx, svcOrSvcExportKey, svc)).Should(Succeed())
 			svc.Spec.Ports = []corev1.ServicePort{
 				{
 					Name:       svcPortName,
@@ -401,12 +401,12 @@ var _ = Describe("serviceexport controller", func() {
 					TargetPort: intstr.FromInt(altTargetPort),
 				},
 			}
-			Expect(MemberClient.Update(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Update(ctx, svc)).Should(Succeed())
 
 			By("confirm that the exported service has been updated")
 			Eventually(func() bool {
 				internalSvcExport := &fleetnetv1alpha1.InternalServiceExport{}
-				if err := HubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
+				if err := hubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
 					return false
 				}
 
@@ -426,7 +426,7 @@ var _ = Describe("serviceexport controller", func() {
 						},
 					},
 					ServiceReference: fleetnetv1alpha1.FromMetaObjects(
-						MemberClusterID,
+						memberClusterID,
 						svc.TypeMeta,
 						svc.ObjectMeta,
 					),
@@ -442,20 +442,20 @@ var _ = Describe("serviceexport controller", func() {
 
 		BeforeEach(func() {
 			svcExport = notYetFulfilledServiceExport()
-			Expect(MemberClient.Create(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svcExport)).Should(Succeed())
 
 			svc = clusterIPService()
-			Expect(MemberClient.Create(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svc)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(MemberClient.Delete(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svc)).Should(Succeed())
 		})
 
 		It("should unexport the service when service export is deleted", func() {
 			By("confirm that the service has been exported")
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
 					return false
 				}
 
@@ -476,7 +476,7 @@ var _ = Describe("serviceexport controller", func() {
 
 			Eventually(func() bool {
 				internalSvcExport := &fleetnetv1alpha1.InternalServiceExport{}
-				if err := HubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
+				if err := hubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
 					return false
 				}
 
@@ -489,7 +489,7 @@ var _ = Describe("serviceexport controller", func() {
 						},
 					},
 					ServiceReference: fleetnetv1alpha1.FromMetaObjects(
-						MemberClusterID,
+						memberClusterID,
 						svc.TypeMeta,
 						svc.ObjectMeta,
 					),
@@ -498,12 +498,12 @@ var _ = Describe("serviceexport controller", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 
 			By("delete the service export")
-			Expect(MemberClient.Delete(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svcExport)).Should(Succeed())
 
 			By("confirm that the service has been unexported")
 			Eventually(func() bool {
 				internalSvcExportList := &fleetnetv1alpha1.InternalServiceExportList{}
-				if err := HubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
+				if err := hubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
 					return false
 				}
 
@@ -518,20 +518,20 @@ var _ = Describe("serviceexport controller", func() {
 
 		BeforeEach(func() {
 			svcExport = notYetFulfilledServiceExport()
-			Expect(MemberClient.Create(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svcExport)).Should(Succeed())
 
 			svc = clusterIPService()
-			Expect(MemberClient.Create(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svc)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(MemberClient.Delete(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svcExport)).Should(Succeed())
 		})
 
 		It("should unexport the service when service is deleted", func() {
 			By("confirm that the service has been exported")
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
 					return false
 				}
 
@@ -552,7 +552,7 @@ var _ = Describe("serviceexport controller", func() {
 
 			Eventually(func() bool {
 				internalSvcExport := &fleetnetv1alpha1.InternalServiceExport{}
-				if err := HubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
+				if err := hubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
 					return false
 				}
 
@@ -565,7 +565,7 @@ var _ = Describe("serviceexport controller", func() {
 						},
 					},
 					ServiceReference: fleetnetv1alpha1.FromMetaObjects(
-						MemberClusterID,
+						memberClusterID,
 						svc.TypeMeta,
 						svc.ObjectMeta,
 					),
@@ -574,12 +574,12 @@ var _ = Describe("serviceexport controller", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 
 			By("delete the service")
-			Expect(MemberClient.Delete(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svc)).Should(Succeed())
 
 			By("confirm that the service has been unexported")
 			Eventually(func() bool {
 				internalSvcExportList := &fleetnetv1alpha1.InternalServiceExportList{}
-				if err := HubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
+				if err := hubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
 					return false
 				}
 
@@ -587,14 +587,14 @@ var _ = Describe("serviceexport controller", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svc); err == nil || !errors.IsNotFound(err) {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svc); err == nil || !errors.IsNotFound(err) {
 					return false
 				}
 				return true
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
 					return false
 				}
 
@@ -615,20 +615,20 @@ var _ = Describe("serviceexport controller", func() {
 
 		BeforeEach(func() {
 			svcExport = notYetFulfilledServiceExport()
-			Expect(MemberClient.Create(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svcExport)).Should(Succeed())
 
 			svc = headlessService()
-			Expect(MemberClient.Create(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svc)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(MemberClient.Delete(ctx, svcExport)).Should(Succeed())
-			Expect(MemberClient.Delete(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svc)).Should(Succeed())
 		})
 
 		It("should mark the service export as invalid (ineligible) + should not export headless service", func() {
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
 					return false
 				}
 
@@ -643,7 +643,7 @@ var _ = Describe("serviceexport controller", func() {
 
 			Consistently(func() bool {
 				internalSvcExportList := &fleetnetv1alpha1.InternalServiceExportList{}
-				if err := HubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
+				if err := hubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
 					return false
 				}
 
@@ -658,20 +658,20 @@ var _ = Describe("serviceexport controller", func() {
 
 		BeforeEach(func() {
 			svcExport = notYetFulfilledServiceExport()
-			Expect(MemberClient.Create(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svcExport)).Should(Succeed())
 
 			svc = externalNameService()
-			Expect(MemberClient.Create(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svc)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(MemberClient.Delete(ctx, svcExport)).Should(Succeed())
-			Expect(MemberClient.Delete(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svc)).Should(Succeed())
 		})
 
 		It("should mark the service export as invalid (ineligible) + should not export external name service", func() {
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
 					return false
 				}
 
@@ -686,7 +686,7 @@ var _ = Describe("serviceexport controller", func() {
 
 			Consistently(func() bool {
 				internalSvcExportList := &fleetnetv1alpha1.InternalServiceExportList{}
-				if err := HubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
+				if err := hubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
 					return false
 				}
 
@@ -701,21 +701,21 @@ var _ = Describe("serviceexport controller", func() {
 
 		BeforeEach(func() {
 			svcExport = notYetFulfilledServiceExport()
-			Expect(MemberClient.Create(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svcExport)).Should(Succeed())
 
 			svc = clusterIPService()
-			Expect(MemberClient.Create(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svc)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(MemberClient.Delete(ctx, svcExport)).Should(Succeed())
-			Expect(MemberClient.Delete(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svc)).Should(Succeed())
 		})
 
 		It("should mark the service export as invalid (ineligible) + should unexport the service", func() {
 			By("confirm that the service has been exported")
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
 					return false
 				}
 
@@ -736,7 +736,7 @@ var _ = Describe("serviceexport controller", func() {
 
 			Eventually(func() bool {
 				internalSvcExport := &fleetnetv1alpha1.InternalServiceExport{}
-				if err := HubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
+				if err := hubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
 					return false
 				}
 
@@ -749,7 +749,7 @@ var _ = Describe("serviceexport controller", func() {
 						},
 					},
 					ServiceReference: fleetnetv1alpha1.FromMetaObjects(
-						MemberClusterID,
+						memberClusterID,
 						svc.TypeMeta,
 						svc.ObjectMeta,
 					),
@@ -758,16 +758,16 @@ var _ = Describe("serviceexport controller", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 
 			By("update the service; set it to an external name service")
-			Expect(MemberClient.Get(ctx, svcOrSvcExportKey, svc)).Should(Succeed())
+			Expect(memberClient.Get(ctx, svcOrSvcExportKey, svc)).Should(Succeed())
 			svc.Spec.Type = corev1.ServiceTypeExternalName
 			svc.Spec.Ports = []corev1.ServicePort{}
 			svc.Spec.ExternalName = externalNameAddr
-			Expect(MemberClient.Update(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Update(ctx, svc)).Should(Succeed())
 
 			By("confirm that the service has been unexported")
 			Eventually(func() bool {
 				internalSvcExportList := &fleetnetv1alpha1.InternalServiceExportList{}
-				if err := HubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
+				if err := hubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
 					return false
 				}
 
@@ -775,7 +775,7 @@ var _ = Describe("serviceexport controller", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
 					return false
 				}
 
@@ -796,20 +796,20 @@ var _ = Describe("serviceexport controller", func() {
 
 		BeforeEach(func() {
 			svcExport = notYetFulfilledServiceExport()
-			Expect(MemberClient.Create(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svcExport)).Should(Succeed())
 
 			svc = externalNameService()
-			Expect(MemberClient.Create(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Create(ctx, svc)).Should(Succeed())
 		})
 
 		AfterEach(func() {
-			Expect(MemberClient.Delete(ctx, svcExport)).Should(Succeed())
-			Expect(MemberClient.Delete(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svcExport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, svc)).Should(Succeed())
 
 			// Confirm that the Service has been unexported; this helps make the tests less flaky.
 			Eventually(func() bool {
 				internalSvcExportList := &fleetnetv1alpha1.InternalServiceExportList{}
-				if err := HubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
+				if err := hubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
 					return false
 				}
 
@@ -817,7 +817,7 @@ var _ = Describe("serviceexport controller", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err == nil || !errors.IsNotFound(err) {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err == nil || !errors.IsNotFound(err) {
 					return false
 				}
 				return true
@@ -828,7 +828,7 @@ var _ = Describe("serviceexport controller", func() {
 			By("confirm that the service has not been exported")
 			Consistently(func() bool {
 				internalSvcExportList := &fleetnetv1alpha1.InternalServiceExportList{}
-				if err := HubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
+				if err := hubClient.List(ctx, internalSvcExportList, &client.ListOptions{Namespace: hubNSForMember}); err != nil {
 					return false
 				}
 
@@ -836,7 +836,7 @@ var _ = Describe("serviceexport controller", func() {
 			}, consistentlyDuration, consistentlyInterval).Should(BeTrue())
 
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
 					return false
 				}
 
@@ -850,7 +850,7 @@ var _ = Describe("serviceexport controller", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(BeTrue())
 
 			By("update the service; set it as a cluster IP service")
-			Expect(MemberClient.Get(ctx, svcOrSvcExportKey, svc)).Should(Succeed())
+			Expect(memberClient.Get(ctx, svcOrSvcExportKey, svc)).Should(Succeed())
 			svc.Spec.Type = corev1.ServiceTypeClusterIP
 			svc.Spec.ExternalName = ""
 			svc.Spec.Ports = []corev1.ServicePort{
@@ -859,11 +859,11 @@ var _ = Describe("serviceexport controller", func() {
 					TargetPort: intstr.FromInt(targetPort),
 				},
 			}
-			Expect(MemberClient.Update(ctx, svc)).Should(Succeed())
+			Expect(memberClient.Update(ctx, svc)).Should(Succeed())
 
 			By("confirm that the service has been exported")
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
+				if err := memberClient.Get(ctx, svcOrSvcExportKey, svcExport); err != nil {
 					return false
 				}
 
@@ -884,7 +884,7 @@ var _ = Describe("serviceexport controller", func() {
 
 			Eventually(func() bool {
 				internalSvcExport := &fleetnetv1alpha1.InternalServiceExport{}
-				if err := HubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
+				if err := hubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
 					return false
 				}
 
@@ -897,7 +897,7 @@ var _ = Describe("serviceexport controller", func() {
 						},
 					},
 					ServiceReference: fleetnetv1alpha1.FromMetaObjects(
-						MemberClusterID,
+						memberClusterID,
 						svc.TypeMeta,
 						svc.ObjectMeta,
 					),

--- a/pkg/controllers/member/serviceexport/suite_test.go
+++ b/pkg/controllers/member/serviceexport/suite_test.go
@@ -27,8 +27,8 @@ import (
 var (
 	memberTestEnv *envtest.Environment
 	hubTestEnv    *envtest.Environment
-	MemberClient  client.Client
-	HubClient     client.Client
+	memberClient  client.Client
+	hubClient     client.Client
 	ctx           context.Context
 	cancel        context.CancelFunc
 )
@@ -41,14 +41,14 @@ func setUpResources() {
 			Name: memberUserNS,
 		},
 	}
-	Expect(MemberClient.Create(ctx, &memberNS)).Should(Succeed())
+	Expect(memberClient.Create(ctx, &memberNS)).Should(Succeed())
 
 	hubNS := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: hubNSForMember,
 		},
 	}
-	Expect(HubClient.Create(ctx, &hubNS)).Should(Succeed())
+	Expect(hubClient.Create(ctx, &hubNS)).Should(Succeed())
 }
 
 func TestAPIs(t *testing.T) {
@@ -85,12 +85,12 @@ var _ = BeforeSuite(func() {
 	Expect(fleetnetv1alpha1.AddToScheme(scheme.Scheme)).Should(Succeed())
 
 	// Set up clients for member and hub clusters.
-	MemberClient, err = client.New(memberCfg, client.Options{Scheme: scheme.Scheme})
+	memberClient, err = client.New(memberCfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(MemberClient).NotTo(BeNil())
-	HubClient, err = client.New(hubCfg, client.Options{Scheme: scheme.Scheme})
+	Expect(memberClient).NotTo(BeNil())
+	hubClient, err = client.New(hubCfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(HubClient).NotTo(BeNil())
+	Expect(hubClient).NotTo(BeNil())
 
 	// Set up resources.
 	setUpResources()
@@ -103,9 +103,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&Reconciler{
-		MemberClusterID: MemberClusterID,
-		MemberClient:    MemberClient,
-		HubClient:       HubClient,
+		MemberClusterID: memberClusterID,
+		MemberClient:    memberClient,
+		HubClient:       hubClient,
 		HubNamespace:    hubNSForMember,
 	}).SetupWithManager(ctrlMgr)
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/controllers/member/serviceimport/controller_integration_test.go
+++ b/pkg/controllers/member/serviceimport/controller_integration_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Create or update a service import", func() {
 				Name: testNamespace,
 			},
 		}
-		Expect(MemberClient.Create(ctx, &testNS)).Should(Succeed())
+		Expect(memberClient.Create(ctx, &testNS)).Should(Succeed())
 	})
 
 	AfterEach(func() {
@@ -45,7 +45,7 @@ var _ = Describe("Create or update a service import", func() {
 				Name: testNamespace,
 			},
 		}
-		Expect(MemberClient.Delete(ctx, &testNS)).Should(Succeed())
+		Expect(memberClient.Delete(ctx, &testNS)).Should(Succeed())
 	})
 
 	When("Create InternalServiceImport from ServiceImport", func() {
@@ -58,11 +58,11 @@ var _ = Describe("Create or update a service import", func() {
 				},
 			}
 			By("By creating a service import")
-			Expect(MemberClient.Create(ctx, serviceImport)).Should(Succeed())
+			Expect(memberClient.Create(ctx, serviceImport)).Should(Succeed())
 			serviceImportLookupKey := types.NamespacedName{Name: serviceImport.Name, Namespace: serviceImport.Namespace}
 			// We'll need to retry getting this newly created ServiceImport, given that creation may not immediately happen.
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, serviceImportLookupKey, serviceImport); err != nil {
+				if err := memberClient.Get(ctx, serviceImportLookupKey, serviceImport); err != nil {
 					return false
 				}
 				finalizers := serviceImport.GetFinalizers()
@@ -79,7 +79,7 @@ var _ = Describe("Create or update a service import", func() {
 			internalServiceImport := &fleetnetv1alpha1.InternalServiceImport{}
 			By("By checking the ServiceImportReference of internal service import is updated")
 			Eventually(func() bool {
-				if err := HubClient.Get(ctx, internalServiceImportLookupKey, internalServiceImport); err != nil {
+				if err := hubClient.Get(ctx, internalServiceImportLookupKey, internalServiceImport); err != nil {
 					return false
 				}
 				return cmp.Equal(expectedServiceImportRef, internalServiceImport.Spec.ServiceImportReference)
@@ -94,11 +94,11 @@ var _ = Describe("Create or update a service import", func() {
 			} else {
 				serviceImport.SetLabels(map[string]string{testLabelKey: testLabelValue})
 			}
-			Expect(MemberClient.Update(ctx, serviceImport)).Should(Succeed())
+			Expect(memberClient.Update(ctx, serviceImport)).Should(Succeed())
 			By("By fetching updated service import")
 			updatedServiceImport := &fleetnetv1alpha1.ServiceImport{}
 			Eventually(func() bool {
-				if err := MemberClient.Get(ctx, serviceImportLookupKey, updatedServiceImport); err != nil {
+				if err := memberClient.Get(ctx, serviceImportLookupKey, updatedServiceImport); err != nil {
 					return false
 				}
 				return updatedServiceImport.GetLabels() != nil && updatedServiceImport.GetLabels()[testLabelKey] == testLabelValue
@@ -107,7 +107,7 @@ var _ = Describe("Create or update a service import", func() {
 			expectedServiceImportRef = fleetnetv1alpha1.FromMetaObjects(MemberClusterID, updatedServiceImport.TypeMeta, updatedServiceImport.ObjectMeta)
 			updatedInternalServiceImport := &fleetnetv1alpha1.InternalServiceImport{}
 			Eventually(func() bool {
-				if err := HubClient.Get(ctx, internalServiceImportLookupKey, updatedInternalServiceImport); err != nil {
+				if err := hubClient.Get(ctx, internalServiceImportLookupKey, updatedInternalServiceImport); err != nil {
 					return false
 				}
 				return cmp.Equal(expectedServiceImportRef, updatedInternalServiceImport.Spec.ServiceImportReference)
@@ -115,11 +115,11 @@ var _ = Describe("Create or update a service import", func() {
 
 			// 3. Check internal service import is deleted after service import is deleted.
 			By("By deleting the service import")
-			Expect(MemberClient.Delete(ctx, serviceImport)).Should(Succeed())
+			Expect(memberClient.Delete(ctx, serviceImport)).Should(Succeed())
 			By("By checking the existence of  service import")
 			serviceImportList := &fleetnetv1alpha1.ServiceImportList{}
 			Eventually(func() (int, error) {
-				if err := MemberClient.List(ctx, serviceImportList, &client.ListOptions{Namespace: testNamespace}); err != nil {
+				if err := memberClient.List(ctx, serviceImportList, &client.ListOptions{Namespace: testNamespace}); err != nil {
 					return -1, err
 				}
 				return len(serviceImportList.Items), nil
@@ -127,7 +127,7 @@ var _ = Describe("Create or update a service import", func() {
 			By("By checking the existence of internal service import")
 			internalServiceImportList := &fleetnetv1alpha1.InternalServiceImportList{}
 			Eventually(func() (int, error) {
-				if err := HubClient.List(ctx, internalServiceImportList, &client.ListOptions{Namespace: HubNamespace}); err != nil {
+				if err := hubClient.List(ctx, internalServiceImportList, &client.ListOptions{Namespace: HubNamespace}); err != nil {
 					return -1, err
 				}
 				return len(internalServiceImportList.Items), nil

--- a/pkg/controllers/member/serviceimport/suite_test.go
+++ b/pkg/controllers/member/serviceimport/suite_test.go
@@ -28,8 +28,8 @@ import (
 var (
 	memberTestEnv *envtest.Environment
 	hubTestEnv    *envtest.Environment
-	MemberClient  client.Client
-	HubClient     client.Client
+	memberClient  client.Client
+	hubClient     client.Client
 	ctx           context.Context
 	cancel        context.CancelFunc
 )
@@ -77,12 +77,12 @@ var _ = BeforeSuite(func() {
 	Expect(fleetnetv1alpha1.AddToScheme(scheme.Scheme)).Should(Succeed())
 
 	// Set up clients for member and hub clusters.
-	MemberClient, err = client.New(memberCfg, client.Options{Scheme: scheme.Scheme})
+	memberClient, err = client.New(memberCfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(MemberClient).NotTo(BeNil())
-	HubClient, err = client.New(hubCfg, client.Options{Scheme: scheme.Scheme})
+	Expect(memberClient).NotTo(BeNil())
+	hubClient, err = client.New(hubCfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(HubClient).NotTo(BeNil())
+	Expect(hubClient).NotTo(BeNil())
 
 	By("starting the controller manager")
 
@@ -95,8 +95,8 @@ var _ = BeforeSuite(func() {
 	err = (&Reconciler{
 		MemberClusterID: MemberClusterID,
 		HubNamespace:    HubNamespace,
-		MemberClient:    MemberClient,
-		HubClient:       HubClient,
+		MemberClient:    memberClient,
+		HubClient:       hubClient,
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -118,7 +118,7 @@ func setupResources() {
 			Name: HubNamespace,
 		},
 	}
-	Expect(HubClient.Create(ctx, &hubNS)).Should(Succeed())
+	Expect(hubClient.Create(ctx, &hubNS)).Should(Succeed())
 }
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION

**What this PR does / why we need it**:

fix the test related variables to avoid using these variables and const accidently

**Requirements**:

- [X] run `make reviewable` for basic local test
- [X] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
