### PR TITLE
fix: add rbac marker to configure cache index

### DIFF
--- a/pkg/controllers/hub/serviceimport/controller.go
+++ b/pkg/controllers/hub/serviceimport/controller.go
@@ -45,7 +45,7 @@ type statusChange struct {
 //+kubebuilder:rbac:groups=networking.fleet.azure.com,resources=serviceimports,verbs=get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=networking.fleet.azure.com,resources=serviceimports/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=networking.fleet.azure.com,resources=serviceimports/finalizers,verbs=update
-//+kubebuilder:rbac:groups=networking.fleet.azure.com,resources=internalserviceexports,verbs=list
+//+kubebuilder:rbac:groups=networking.fleet.azure.com,resources=internalserviceexports,verbs=get;watch;list
 //+kubebuilder:rbac:groups=networking.fleet.azure.com,resources=internalserviceexports/status,verbs=get;update;patch
 
 // Reconcile resolves the service spec when the serviceImport status is empty and updates the status of internalServiceExports.


### PR DESCRIPTION
/kind cleanup

**Which issue(s) this PR fixes**:
Fix the rbac marker for the serviceImport controller.
Hub controller won't fail because the missing rbac is added by other controllers.

**Requirements**:

- [X] run `make reviewable` for basic local test
- [X] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [N/A] includes documentation
- [N/A] adds unit tests