### PR TITLE
fix: make the integration tests of the InternalServiceImport controller less flaky

### DIFF
--- a/pkg/controllers/hub/internalserviceimport/controller_integration_test.go
+++ b/pkg/controllers/hub/internalserviceimport/controller_integration_test.go
@@ -242,7 +242,7 @@ var _ = Describe("internalserviceimport controller", Ordered, func() {
 			Expect(client.IgnoreNotFound(hubClient.Delete(ctx, internalSvcImport))).Should(Succeed())
 			Eventually(func() error {
 				return client.IgnoreNotFound(hubClient.Get(ctx, internalSvcImportAKey, internalSvcImport))
-			}, eventuallyTimeout, eventuallyInterval)
+			}, eventuallyTimeout, eventuallyInterval).Should(BeNil())
 
 			Expect(hubClient.Delete(ctx, svcImport)).Should(Succeed())
 			// Confirm that ServiceImport is deleted; this helps make the test less flaky.


### PR DESCRIPTION
**What type of PR is this?**

/kind test
/kind flake

**What this PR does / why we need it**:

This PR helps make the integration tests of the InternalServiceImport controller (specifically the 3rd test case) less flaky.

**Which issue(s) this PR fixes**:

N/A

**Requirements**:

- [x] run `make reviewable` for basic local test
- [x] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [N/A] includes documentation
- [N/A] adds unit tests

### How has this code been tested

N/A

### Special notes for your reviewer

