### PR TITLE
fix: updated scheme in use by controllers + restore fleetSystemNamespace field in hub controller chart

### DIFF
--- a/charts/hub-net-controller-manager/README.md
+++ b/charts/hub-net-controller-manager/README.md
@@ -34,6 +34,7 @@ helm upgrade hub-net-controller-manager ./charts/hub-net-controller-manager/
 | image.tag | The image tag to use | `v0.1.0` |
 | logVerbosity | Log level. Uses V logs (klog) | `2` |
 | leaderElectionNamespace | The namespace in which the leader election resource will be created. | `fleet-system` |
+| fleetSystemNamespace | The namespace that this Helm chart is installed on and reserved by fleet. | `fleet-system` |
 | resources | The resource request/limits for the container image | limits: 500m CPU, 1Gi, requests: 100m CPU, 128Mi |
 | podAnnotations | Pod Annotations | `{}` |
 | affinity | The node affinity to use for pod scheduling | `{}` |

--- a/charts/hub-net-controller-manager/values.yaml
+++ b/charts/hub-net-controller-manager/values.yaml
@@ -13,6 +13,7 @@ image:
 logVerbosity: 2
 
 leaderElectionNamespace: fleet-system
+fleetSystemNamespace: fleet-system
 
 resources:
   limits:

--- a/cmd/mcs-controller-manager/main.go
+++ b/cmd/mcs-controller-manager/main.go
@@ -57,6 +57,7 @@ func init() {
 
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(fleetnetv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(fleetv1alpha1.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }

--- a/cmd/member-net-controller-manager/main.go
+++ b/cmd/member-net-controller-manager/main.go
@@ -57,9 +57,11 @@ var (
 )
 
 func init() {
+	klog.InitFlags(nil)
+
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(fleetnetv1alpha1.AddToScheme(scheme))
-	klog.InitFlags(nil)
+	utilruntime.Must(fleetv1alpha1.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes the problem of missing Fleet APIs in the scheme and addresses [this comment](https://github.com/Azure/fleet-networking/pull/87#discussion_r941000702) about the `fleetSystemNamespace` field in the hub controller chart.

**Which issue(s) this PR fixes**:

N/A

**Requirements**:

- [x] run `make reviewable` for basic local test
- [x] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [N/A] includes documentation
- [N/A] adds unit tests

### How has this code been tested

N/A

### Special notes for your reviewer

