### PR TITLE
fix: use member cluster for the leader election instead

### DIFF
--- a/cmd/member-net-controller-manager/main.go
+++ b/cmd/member-net-controller-manager/main.go
@@ -86,12 +86,12 @@ func main() {
 		klog.InfoS("flag:", "name", f.Name, "value", f.Value)
 	})
 
-	hubConfig, hubOptions, err := prepareHubParameters()
+	memberConfig, memberOptions := prepareMemberParameters()
+
+	hubConfig, hubOptions, err := prepareHubParameters(memberConfig)
 	if err != nil {
 		exitWithErrorFunc()
 	}
-
-	memberConfig, memberOptions := prepareMemberParameters()
 
 	// Setup hub controller manager.
 	hubMgr, err := ctrl.NewManager(hubConfig, *hubOptions)
@@ -176,7 +176,7 @@ func main() {
 	}
 }
 
-func prepareHubParameters() (*rest.Config, *ctrl.Options, error) {
+func prepareHubParameters(memberConfig *rest.Config) (*rest.Config, *ctrl.Options, error) {
 	hubConfig, err := hubconfig.PrepareHubConfig(*tlsClientInsecure)
 	if err != nil {
 		klog.ErrorS(err, "Failed to get hub config")
@@ -196,7 +196,8 @@ func prepareHubParameters() (*rest.Config, *ctrl.Options, error) {
 		HealthProbeBindAddress:  *hubProbeAddr,
 		LeaderElection:          *enableLeaderElection,
 		LeaderElectionID:        "2bf2b407.hub.networking.fleet.azure.com",
-		LeaderElectionNamespace: mcHubNamespace, // This requires we have access to resource "leases" in API group "coordination.k8s.io" under namespace $mcHubNamespace
+		LeaderElectionNamespace: *leaderElectionNamespace, // This requires we have access to resource "leases" in API group "coordination.k8s.io" under leaderElectionNamespace.
+		LeaderElectionConfig:    memberConfig,
 		Namespace:               mcHubNamespace, // Restricts the manager's cache to watch objects in the member hub namespace.
 	}
 	return hubConfig, hubOptions, nil


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:
To reduce the hub cluster API server call, move the leader election to the member cluster.

**Requirements**:

- [X] run `make reviewable` for basic local test
- [X] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested
integration test

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
