### PR TITLE
fix: set linux timestamp as rand seed to avoid conflicts

### DIFF
--- a/pkg/common/uniquename/uniquename.go
+++ b/pkg/common/uniquename/uniquename.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
+	"time"
 	"unicode"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -29,6 +30,10 @@ const (
 
 	uuidLength = 5
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 // minInt returns the smaller one of two integers.
 func minInt(a, b int) int {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
rand seed is to initialize the default Source to a deterministic state and is assigned to be 1 by default, which will produce the same deterministic sequence of values.

https://pkg.go.dev/math/rand#Seed

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] run `make reviewable` for basic local test
- [x] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to be tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
