### PR TITLE
fix: add jitter when updating imc

### DIFF
--- a/cmd/hub-net-controller-manager/main.go
+++ b/cmd/hub-net-controller-manager/main.go
@@ -15,6 +15,7 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -55,6 +56,7 @@ func init() {
 
 func main() {
 	flag.Parse()
+	rand.Seed(time.Now().UnixNano())
 
 	handleExitFunc := func() {
 		klog.Flush()

--- a/cmd/mcs-controller-manager/main.go
+++ b/cmd/mcs-controller-manager/main.go
@@ -13,7 +13,9 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
+	"k8s.io/apimachinery/pkg/util/rand"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -64,6 +66,7 @@ func init() {
 
 func main() {
 	flag.Parse()
+	rand.Seed(time.Now().UnixNano())
 
 	handleExitFunc := func() {
 		klog.Flush()

--- a/cmd/member-net-controller-manager/main.go
+++ b/cmd/member-net-controller-manager/main.go
@@ -14,10 +14,12 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -70,6 +72,7 @@ func init() {
 
 func main() {
 	flag.Parse()
+	rand.Seed(time.Now().UnixNano())
 
 	handleExitFunc := func() {
 		klog.Flush()

--- a/pkg/common/uniquename/uniquename.go
+++ b/pkg/common/uniquename/uniquename.go
@@ -9,11 +9,10 @@ package uniquename
 
 import (
 	"fmt"
-	"math/rand"
 	"strings"
-	"time"
 	"unicode"
 
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -30,10 +29,6 @@ const (
 
 	uuidLength = 5
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 // minInt returns the smaller one of two integers.
 func minInt(a, b int) int {

--- a/pkg/controllers/member/internalmembercluster/controller.go
+++ b/pkg/controllers/member/internalmembercluster/controller.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +32,9 @@ import (
 const (
 	conditionReasonJoined = "AgentJoined"
 	conditionReasonLeft   = "AgentLeft"
+
+	// we add +-5% jitter
+	jitterPercent = 10
 )
 
 // Reconciler reconciles a InternalMemberCluster object.
@@ -80,7 +84,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if err := r.updateAgentStatus(ctx, &imc, agentStatus); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{RequeueAfter: time.Second * time.Duration(imc.Spec.HeartbeatPeriodSeconds)}, nil
+		// add jitter to the heart beat to mitigate the herding of multiple agents
+		hbInterval := 1000 * imc.Spec.HeartbeatPeriodSeconds
+		jitterRange := int64(hbInterval*jitterPercent) / 100
+		requeueAfter := time.Millisecond * (time.Duration(hbInterval) + time.Duration(rand.Int63nRange(0, jitterRange)-jitterRange/2))
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	case fleetv1alpha1.ClusterStateLeave:
 		if r.AgentType == fleetv1alpha1.MultiClusterServiceAgent {
 			if err := r.cleanupMCSRelatedResources(ctx); err != nil {

--- a/pkg/controllers/multiclusterservice/controller.go
+++ b/pkg/controllers/multiclusterservice/controller.go
@@ -342,7 +342,7 @@ func (r *Reconciler) updateMultiClusterServiceStatus(ctx context.Context, mcs *f
 			Status:             metav1.ConditionUnknown,
 			Reason:             conditionReasonUnknownServiceImport,
 			ObservedGeneration: mcs.GetGeneration(),
-			Message:            "importing service; if the condition remains for a while, please verify that service has been exported",
+			Message:            "importing service; if the condition remains for a while, please verify that service has been exported or service has been exported by other multiClusterService",
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

- heartbeat will fail when multiple agents update the imc at the same time.Thus, adding  jitter to reduce the conflict possibility.
- Update mcs condition message to cover mcs won't work if service has been exported by other mcs.
- Use api machinery rand package to generate random number instead of using two packages.


**Requirements**:

- [X] run `make reviewable` for basic local test
- [X] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to be tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
