### PR TITLE
test: make hybrid protocol service related tests optional

### DIFF
--- a/pkg/controllers/hub/endpointsliceexport/controller_integration_test.go
+++ b/pkg/controllers/hub/endpointsliceexport/controller_integration_test.go
@@ -74,10 +74,10 @@ func fulfillSvcImport(svcImport *fleetnetv1alpha1.ServiceImport) {
 				Port:        httpPort,
 			},
 			{
-				Name:        udpPortName,
-				Protocol:    udpPortProtocol,
-				AppProtocol: &udpPortAppProtocol,
-				Port:        udpPort,
+				Name:        tcpPortName,
+				Protocol:    tcpPortProtocol,
+				AppProtocol: &tcpPortAppProtocol,
+				Port:        tcpPort,
 			},
 		},
 		Clusters: []fleetnetv1alpha1.ClusterStatus{

--- a/pkg/controllers/hub/endpointsliceexport/controller_test.go
+++ b/pkg/controllers/hub/endpointsliceexport/controller_test.go
@@ -46,10 +46,10 @@ var (
 	httpPort            = int32(80)
 	httpPortProtocol    = corev1.ProtocolTCP
 	httpPortAppProtocol = "www"
-	udpPortName         = "udp"
-	udpPort             = int32(81)
-	udpPortProtocol     = corev1.ProtocolUDP
-	udpPortAppProtocol  = "example.com/custom"
+	tcpPortName         = "tcp"
+	tcpPort             = int32(81)
+	tcpPortProtocol     = corev1.ProtocolTCP
+	tcpPortAppProtocol  = "example.com/custom"
 
 	ignoredObjectMetaFields = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")
 )
@@ -80,10 +80,10 @@ func ipv4EndpointSliceExport() *fleetnetv1alpha1.EndpointSliceExport {
 					AppProtocol: &httpPortAppProtocol,
 				},
 				{
-					Name:        &udpPortName,
-					Protocol:    &udpPortProtocol,
-					Port:        &udpPort,
-					AppProtocol: &udpPortAppProtocol,
+					Name:        &tcpPortName,
+					Protocol:    &tcpPortProtocol,
+					Port:        &tcpPort,
+					AppProtocol: &tcpPortAppProtocol,
 				},
 			},
 			EndpointSliceReference: fleetnetv1alpha1.ExportedObjectReference{

--- a/pkg/controllers/hub/internalserviceimport/controller_integration_test.go
+++ b/pkg/controllers/hub/internalserviceimport/controller_integration_test.go
@@ -58,10 +58,10 @@ func fulfillInternalServiceImport(internalSvcImport *fleetnetv1alpha1.InternalSe
 				Port:        httpPort,
 			},
 			{
-				Name:        udpPortName,
-				Protocol:    udpPortProtocol,
-				AppProtocol: &udpPortAppProtocol,
-				Port:        udpPort,
+				Name:        tcpPortName,
+				Protocol:    tcpPortProtocol,
+				AppProtocol: &tcpPortAppProtocol,
+				Port:        tcpPort,
 			},
 		},
 		Clusters: []fleetnetv1alpha1.ClusterStatus{
@@ -104,10 +104,10 @@ func fulfillServiceImport(svcImport *fleetnetv1alpha1.ServiceImport) {
 				Port:        httpPort,
 			},
 			{
-				Name:        udpPortName,
-				Protocol:    udpPortProtocol,
-				AppProtocol: &udpPortAppProtocol,
-				Port:        udpPort,
+				Name:        tcpPortName,
+				Protocol:    tcpPortProtocol,
+				AppProtocol: &tcpPortAppProtocol,
+				Port:        tcpPort,
 			},
 		},
 		Clusters: []fleetnetv1alpha1.ClusterStatus{

--- a/pkg/controllers/hub/internalserviceimport/controller_test.go
+++ b/pkg/controllers/hub/internalserviceimport/controller_test.go
@@ -46,10 +46,10 @@ var (
 	httpPort            = int32(80)
 	httpPortProtocol    = corev1.ProtocolTCP
 	httpPortAppProtocol = "www"
-	udpPortName         = "udp"
-	udpPort             = int32(81)
-	udpPortProtocol     = corev1.ProtocolUDP
-	udpPortAppProtocol  = "example.com/custom"
+	tcpPortName         = "tcp"
+	tcpPort             = int32(81)
+	tcpPortProtocol     = corev1.ProtocolTCP
+	tcpPortAppProtocol  = "example.com/custom"
 )
 
 // fulfilledSvcInUseByAnnotation returns a fulfilled ServiceInUseBy for annotation use.
@@ -88,10 +88,10 @@ func fulfilledServiceImport() *fleetnetv1alpha1.ServiceImport {
 					Port:        httpPort,
 				},
 				{
-					Name:        udpPortName,
-					Protocol:    udpPortProtocol,
-					AppProtocol: &udpPortAppProtocol,
-					Port:        udpPort,
+					Name:        tcpPortName,
+					Protocol:    tcpPortProtocol,
+					AppProtocol: &tcpPortAppProtocol,
+					Port:        tcpPort,
 				},
 			},
 			Clusters: []fleetnetv1alpha1.ClusterStatus{

--- a/pkg/controllers/member/endpointsliceimport/controller_test.go
+++ b/pkg/controllers/member/endpointsliceimport/controller_test.go
@@ -38,10 +38,14 @@ var (
 	httpPort            = int32(80)
 	httpPortProtocol    = corev1.ProtocolTCP
 	httpPortAppProtocol = "www"
+	tcpPortName         = "tcp"
+	tcpPort             = int32(81)
+	tcpPortProtocol     = corev1.ProtocolTCP
+	tcpPortAppProtocol  = "example.com/custom"
 	udpPortName         = "udp"
-	udpPort             = int32(81)
+	udpPort             = int32(82)
 	udpPortProtocol     = corev1.ProtocolUDP
-	udpPortAppProtocol  = "example.com/custom"
+	udpPortAppProtocol  = "example.com/custom-2"
 )
 
 // Bootstrap the test environment.
@@ -79,10 +83,10 @@ func ipv4EndpointSliceImport() *fleetnetv1alpha1.EndpointSliceImport {
 					AppProtocol: &httpPortAppProtocol,
 				},
 				{
-					Name:        &udpPortName,
-					Protocol:    &udpPortProtocol,
-					Port:        &udpPort,
-					AppProtocol: &udpPortAppProtocol,
+					Name:        &tcpPortName,
+					Protocol:    &tcpPortProtocol,
+					Port:        &tcpPort,
+					AppProtocol: &tcpPortAppProtocol,
 				},
 			},
 			EndpointSliceReference: fleetnetv1alpha1.ExportedObjectReference{
@@ -100,6 +104,18 @@ func ipv4EndpointSliceImport() *fleetnetv1alpha1.EndpointSliceImport {
 			},
 		},
 	}
+}
+
+// ipv4EndpointSliceImportWithHybridProtocol returns an EndpointSliceImport with both TCP and UDP ports.
+func ipv4EndpointSliceImportWithHybridProtocol() *fleetnetv1alpha1.EndpointSliceImport {
+	endpointSliceImport := ipv4EndpointSliceImport()
+	endpointSliceImport.Spec.Ports[0] = discoveryv1.EndpointPort{
+		Name:        &udpPortName,
+		Protocol:    &udpPortProtocol,
+		Port:        &udpPort,
+		AppProtocol: &udpPortAppProtocol,
+	}
+	return endpointSliceImport
 }
 
 // importedIPv4EndpointSlice returns an EndpointSlice.
@@ -130,13 +146,25 @@ func importedIPv4EndpointSlice() *discoveryv1.EndpointSlice {
 				AppProtocol: &httpPortAppProtocol,
 			},
 			{
-				Name:        &udpPortName,
-				Protocol:    &udpPortProtocol,
-				Port:        &udpPort,
-				AppProtocol: &udpPortAppProtocol,
+				Name:        &tcpPortName,
+				Protocol:    &tcpPortProtocol,
+				Port:        &tcpPort,
+				AppProtocol: &tcpPortAppProtocol,
 			},
 		},
 	}
+}
+
+// importedIPV4EndpointSliceWithHybridProtocol returns an EndpointSlice with both TCP and UDP ports.
+func importedIPv4EndpointSliceWithHybridProtocol() *discoveryv1.EndpointSlice {
+	endpointSlice := importedIPv4EndpointSlice()
+	endpointSlice.Ports[0] = discoveryv1.EndpointPort{
+		Name:        &udpPortName,
+		Protocol:    &udpPortProtocol,
+		Port:        &udpPort,
+		AppProtocol: &udpPortAppProtocol,
+	}
+	return endpointSlice
 }
 
 // TestScanForDerivedServiceName tests the scanForDerivedServiceName function.


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

This PR makes tests related to hybrid protocol Services optional, as such Services are not supported by default in Kubernetes versions earlier than 1.24.

**Which issue(s) this PR fixes**:

N/A

**Requirements**:

- [x] run `make reviewable` for basic local test
- [x] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [N/A] includes documentation
- [N/A] adds unit tests

### How has this code been tested

N/A

### Special notes for your reviewer
