### PR TITLE
test: run the test against prod k8s version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.x
-ENVTEST_K8S_VER = latest
 ENVTEST_K8S_BIN := setup-envtest
 ENVTEST :=  $(abspath $(TOOLS_BIN_DIR)/$(ENVTEST_K8S_BIN)-$(ENVTEST_K8S_VER))
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
We currently run the integration test against the latest k8s API version that controller runtime support. We need to run against the version we will run in production.

[original PR](https://github.com/Azure/fleet-networking/pull/117)

**Requirements**:

- [X] run `make reviewable` for basic local test
- [X] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to be tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
