### PR TITLE
fix: add omitempty JSON tag to exportedSince field

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -43,7 +43,7 @@ type ExportedObjectReference struct {
 	// The timestamp from a local clock when the generation of the object is exported.
 	// This field is marked as optional for backwards compatibility reasons.
 	// +kubebuilder:validation:Optional
-	ExportedSince metav1.Time `json:"exportedSince"`
+	ExportedSince metav1.Time `json:"exportedSince,omitempty"`
 }
 
 // FromMetaObjects builds a new ExportedObjectReference using TypeMeta and ObjectMeta fields from an object.

--- a/config/crd/bases/networking.fleet.azure.com_endpointsliceexports.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_endpointsliceexports.yaml
@@ -59,7 +59,7 @@ spec:
                   exportedSince:
                     description: The timestamp from a local clock when the generation
                       of the object is exported. This field is marked as optional
-                      for compatibility reasons.
+                      for backwards compatibility reasons.
                     format: date-time
                     type: string
                   generation:

--- a/config/crd/bases/networking.fleet.azure.com_endpointsliceimports.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_endpointsliceimports.yaml
@@ -59,7 +59,7 @@ spec:
                   exportedSince:
                     description: The timestamp from a local clock when the generation
                       of the object is exported. This field is marked as optional
-                      for compatibility reasons.
+                      for backwards compatibility reasons.
                     format: date-time
                     type: string
                   generation:

--- a/config/crd/bases/networking.fleet.azure.com_internalserviceexports.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_internalserviceexports.yaml
@@ -102,7 +102,7 @@ spec:
                   exportedSince:
                     description: The timestamp from a local clock when the generation
                       of the object is exported. This field is marked as optional
-                      for compatibility reasons.
+                      for backwards compatibility reasons.
                     format: date-time
                     type: string
                   generation:

--- a/config/crd/bases/networking.fleet.azure.com_internalserviceimports.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_internalserviceimports.yaml
@@ -56,7 +56,7 @@ spec:
                   exportedSince:
                     description: The timestamp from a local clock when the generation
                       of the object is exported. This field is marked as optional
-                      for compatibility reasons.
+                      for backwards compatibility reasons.
                     format: date-time
                     type: string
                   generation:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind api-change

**What this PR does / why we need it**:

This PR adds the `omitempty` JSON tag to the `exportedSince` optional field.

**Which issue(s) this PR fixes**:

N/A

**Requirements**:

- [x] run `make reviewable` for basic local test
- [x] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [N/A] includes documentation
- [N/A] adds unit tests

### How has this code been tested

N/A

### Special notes for your reviewer

N/A
