### PR TITLE
fix: service export metrics + corner cases

### DIFF
--- a/pkg/common/metrics/metrics.go
+++ b/pkg/common/metrics/metrics.go
@@ -16,15 +16,27 @@ const (
 	// an object; this annotation is reserved for the purpose of metric collection, specifically
 	// tracking when a generation of an object is exported.
 	MetricsAnnotationLastSeenGeneration = "networking.fleet.azure.com/last-seen-generation"
-	// MetricsAnnotationLastSeenTimestamp is an annotation that marks the last seen timestamp of
-	// a specific generation of an object; this annotation is reserved for the purpose of metric collection,
-	// specifically tracking when a generation of an object is exported.
-	MetricsAnnotationLastSeenTimestamp = "networking.fleet.azure.com/last-seen-timestamp"
+	// MetricsAnnotationLastSeenResourceVersion is an annotation that marks the last seen resource version of an
+	// an object; this annotation is reserved for the purpose of metric collection, specifically
+	// tracking when a generation of an object is exported.
+	// For most objects, we use their generation field to track whether a data point has been collected; however,
+	// Kubernetes API server tracks generations only on specific types of objects, and for unsupported objects,
+	// their resource versions will be used instead.
+	MetricsAnnotationLastSeenResourceVersion = "networking.fleet.azure.com/last-seen-resource-version"
 
 	// MetricsAnnotationLastObservedGeneration is an annotation that marks the last generation of an
 	// object from which a metric data point has been observed. This helps avoid observing multiple
 	// data points for the same generation of an object.
 	MetricsAnnotationLastObservedGeneration = "networking.fleet.azure.com/last-observed-generation"
+	// MetricsAnnotationLastObservedResourceVersion is an annotation that marks the last resource version of an
+	// object from which a metric data point has been observed. This helps avoid observing multiple
+	// data points for the same generation of an object.
+	MetricsAnnotationLastObservedResourceVersion = "networking.fleet.azure.com/last-observed-resource-version"
+
+	// MetricsAnnotationLastSeenTimestamp is an annotation that marks the last seen timestamp of
+	// a specific generation of an object; this annotation is reserved for the purpose of metric collection,
+	// specifically tracking when a generation of an object is exported.
+	MetricsAnnotationLastSeenTimestamp = "networking.fleet.azure.com/last-seen-timestamp"
 )
 
 // Metrics related values.

--- a/pkg/controllers/member/internalserviceexport/controller_integration_test.go
+++ b/pkg/controllers/member/internalserviceexport/controller_integration_test.go
@@ -46,18 +46,18 @@ var (
 		}
 		return nil
 	}
-	// internalServiceExportHasLastObservedGenerationAnnotatedActual runs with Eventually and Consistently assertion
+	// internalServiceExportHasLastObservedResourceVersionAnnotatedActual runs with Eventually and Consistently assertion
 	// to make sure that a last observed annotation has been added to the InternalServiceExport referred by
 	// internalSvcExportKey when a metric data point is observed.
-	internalServiceExportHasLastObservedGenerationAnnotatedActual = func() error {
+	internalServiceExportHasLastObservedResourceVersionAnnotatedActual = func() error {
 		internalSvcExport := &fleetnetv1alpha1.InternalServiceExport{}
 		if err := hubClient.Get(ctx, internalSvcExportKey, internalSvcExport); err != nil {
 			return fmt.Errorf("internalServiceExport Get(%+v), got %w, want no error", internalSvcExportKey, err)
 		}
 
-		lastObservedGeneration, ok := internalSvcExport.Annotations[metrics.MetricsAnnotationLastObservedGeneration]
-		if !ok || lastObservedGeneration != fmt.Sprintf("%d", internalSvcExport.Spec.ServiceReference.Generation) {
-			return fmt.Errorf("lastObservedGeneration, got %s, want %d", lastObservedGeneration, internalSvcExport.Spec.ServiceReference.Generation)
+		lastObservedResourceVersion, ok := internalSvcExport.Annotations[metrics.MetricsAnnotationLastObservedResourceVersion]
+		if !ok || lastObservedResourceVersion != internalSvcExport.Spec.ServiceReference.ResourceVersion {
+			return fmt.Errorf("lastObservedResourceVersion, got %s, want %s", lastObservedResourceVersion, internalSvcExport.Spec.ServiceReference.ResourceVersion)
 		}
 		return nil
 	}
@@ -81,8 +81,7 @@ func unfulfilledInternalServiceExport() *fleetnetv1alpha1.InternalServiceExport 
 				Kind:            "Service",
 				Namespace:       memberUserNS,
 				Name:            svcName,
-				ResourceVersion: "0",
-				Generation:      1,
+				ResourceVersion: svcResourceVersion,
 				UID:             "00000000-0000-0000-0000-000000000000",
 				ExportedSince:   metav1.NewTime(time.Now().Round(time.Second)),
 			},
@@ -153,8 +152,8 @@ var _ = Describe("internalsvcexport controller", func() {
 					return fmt.Errorf("internalServiceExport Get(%v), got %w, want no error", internalSvcExportKey, err)
 				}
 
-				if _, ok := internalSvcExport.Annotations[metrics.MetricsAnnotationLastObservedGeneration]; ok {
-					return fmt.Errorf("lastObservedGeneration annotation is present")
+				if _, ok := internalSvcExport.Annotations[metrics.MetricsAnnotationLastObservedResourceVersion]; ok {
+					return fmt.Errorf("lastObservedResourceVersion annotation is present")
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(BeNil())
@@ -201,7 +200,7 @@ var _ = Describe("internalsvcexport controller", func() {
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(BeNil())
 
-			Eventually(internalServiceExportHasLastObservedGenerationAnnotatedActual, eventuallyTimeout, eventuallyInterval).Should(BeNil())
+			Eventually(internalServiceExportHasLastObservedResourceVersionAnnotatedActual, eventuallyTimeout, eventuallyInterval).Should(BeNil())
 		})
 	})
 
@@ -245,7 +244,7 @@ var _ = Describe("internalsvcexport controller", func() {
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(BeNil())
 
-			Eventually(internalServiceExportHasLastObservedGenerationAnnotatedActual, eventuallyTimeout, eventuallyInterval).Should(BeNil())
+			Eventually(internalServiceExportHasLastObservedResourceVersionAnnotatedActual, eventuallyTimeout, eventuallyInterval).Should(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes the following issues:

* Use resource versions rather than generations to track last seen/observed data in service exports, as Kubernetes does not track service generations
* Address a corner racing condition which may lead the controller to unexport services unexpectedly.

It also fixes a minor issue that may lead to flaky endpointSlice controller integration tests.

**Which issue(s) this PR fixes**:

N/A

**Requirements**:

- [x] run `make reviewable` for basic local test
- [x] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [N/A] includes documentation
- [x] adds unit tests

### How has this code been tested

[x] unit tests
[x] integration tests

### Special notes for your reviewer


