### PR TITLE
fix: add cluster API to the scheme in related controllers

### DIFF
--- a/cmd/mcs-controller-manager/main.go
+++ b/cmd/mcs-controller-manager/main.go
@@ -65,6 +65,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(fleetnetv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(fleetv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(clusterv1beta1.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }

--- a/cmd/member-net-controller-manager/main.go
+++ b/cmd/member-net-controller-manager/main.go
@@ -71,6 +71,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(fleetnetv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(fleetv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(clusterv1beta1.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR adds the cluster API to the scheduler in related controllers so that they can function when v1beta1 API is enabled.

**Which issue(s) this PR fixes**:

**Requirements**:

- [x] run `make reviewable` for basic local test
- [x] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [N/A] includes documentation
- [N/A] adds unit tests

### How has this code been tested

### Special notes for your reviewer

