### PR TITLE
test: update the e2e test to use v1beta1 imc

### DIFF
--- a/charts/mcs-controller-manager/values.yaml
+++ b/charts/mcs-controller-manager/values.yaml
@@ -51,5 +51,5 @@ tolerations: []
 
 affinity: {}
 
-enableV1Alpha1APIs: true
-enableV1Beta1APIs: false
+enableV1Alpha1APIs: false
+enableV1Beta1APIs: true

--- a/charts/member-net-controller-manager/values.yaml
+++ b/charts/member-net-controller-manager/values.yaml
@@ -51,5 +51,5 @@ tolerations: []
 
 affinity: {}
 
-enableV1Alpha1APIs: true
-enableV1Beta1APIs: false
+enableV1Alpha1APIs: false
+enableV1Beta1APIs: true

--- a/config/crd/bases/networking.fleet.azure.com_endpointsliceexports.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_endpointsliceexports.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: endpointsliceexports.networking.fleet.azure.com
 spec:
   group: networking.fleet.azure.com
@@ -21,18 +19,24 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: EndpointSliceExport is a data transport type that member clusters
-          in the fleet use to upload the spec of an EndpointSlice to the hub cluster.
+        description: |-
+          EndpointSliceExport is a data transport type that member clusters in the fleet use to upload the spec of an
+          EndpointSlice to the hub cluster.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -42,7 +46,8 @@ spec:
             properties:
               addressType:
                 default: IPv4
-                description: The type of addresses carried by this EndpointSliceExport.
+                description: |-
+                  The type of addresses carried by this EndpointSliceExport.
                   At this stage only IPv4 addresses are supported.
                 enum:
                 - IPv4
@@ -57,9 +62,9 @@ spec:
                     description: The ID of the cluster where the object is exported.
                     type: string
                   exportedSince:
-                    description: The timestamp from a local clock when the generation
-                      of the object is exported. This field is marked as optional
-                      for backwards compatibility reasons.
+                    description: |-
+                      The timestamp from a local clock when the generation of the object is exported.
+                      This field is marked as optional for backwards compatibility reasons.
                     format: date-time
                     type: string
                   generation:
@@ -94,6 +99,7 @@ spec:
                 - resourceVersion
                 - uid
                 type: object
+                x-kubernetes-map-type: atomic
               endpoints:
                 description: A list of unique endpoints in the exported EndpointSlice.
                 items:
@@ -101,10 +107,11 @@ spec:
                     backend.
                   properties:
                     addresses:
-                      description: Addresses of the Endpoint. Addresses should be
-                        interpreted per its owner EndpointSliceExport's addressType
-                        field. This field contains at least one address and at maximum
-                        100; for more information about this constraint, see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#endpoint-v1beta1-discovery-k8s-io.
+                      description: |-
+                        Addresses of the Endpoint.
+                        Addresses should be interpreted per its owner EndpointSliceExport's addressType field. This field contains
+                        at least one address and at maximum 100; for more information about this constraint,
+                        see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#endpoint-v1beta1-discovery-k8s-io.
                       items:
                         type: string
                       type: array
@@ -131,51 +138,60 @@ spec:
                 - namespacedName
                 type: object
               ports:
-                description: The list of ports exported by each endpoint in this EndpointSliceExport.
-                  Each port must have a unique name. When the field is empty, it indicates
-                  that there are no defined ports. When a port is defined with a nil
-                  port value, it indicates that all ports are exported. Each slice
-                  may include a maximum of 100 ports.
+                description: |-
+                  The list of ports exported by each endpoint in this EndpointSliceExport. Each port must have a unique name.
+                  When the field is empty, it indicates that there are no defined ports. When a port is defined with a nil
+                  port value, it indicates that all ports are exported. Each slice may include a maximum of 100 ports.
                 items:
                   description: EndpointPort represents a Port used by an EndpointSlice
                   properties:
                     appProtocol:
-                      description: "The application protocol for this port. This is
-                        used as a hint for implementations to offer richer behavior
-                        for protocols that they understand. This field follows standard
-                        Kubernetes label syntax. Valid values are either: \n * Un-prefixed
-                        protocol names - reserved for IANA standard service names
-                        (as per RFC-6335 and https://www.iana.org/assignments/service-names).
-                        \n * Kubernetes-defined prefixed names:   * 'kubernetes.io/h2c'
-                        - HTTP/2 over cleartext as described in https://www.rfc-editor.org/rfc/rfc7540
-                        \  * 'kubernetes.io/ws'  - WebSocket over cleartext as described
-                        in https://www.rfc-editor.org/rfc/rfc6455   * 'kubernetes.io/wss'
-                        - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
-                        \n * Other protocols should use implementation-defined prefixed
-                        names such as mycompany.com/my-custom-protocol."
+                      description: |-
+                        The application protocol for this port.
+                        This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                        This field follows standard Kubernetes label syntax.
+                        Valid values are either:
+
+
+                        * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                        RFC-6335 and https://www.iana.org/assignments/service-names).
+
+
+                        * Kubernetes-defined prefixed names:
+                          * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                          * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                          * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+
+                        * Other protocols should use implementation-defined prefixed names such as
+                        mycompany.com/my-custom-protocol.
                       type: string
                     name:
-                      description: 'name represents the name of this port. All ports
-                        in an EndpointSlice must have a unique name. If the EndpointSlice
-                        is dervied from a Kubernetes service, this corresponds to
-                        the Service.ports[].name. Name must either be an empty string
-                        or pass DNS_LABEL validation: * must be no more than 63 characters
-                        long. * must consist of lower case alphanumeric characters
-                        or ''-''. * must start and end with an alphanumeric character.
-                        Default is empty string.'
+                      description: |-
+                        name represents the name of this port. All ports in an EndpointSlice must have a unique name.
+                        If the EndpointSlice is derived from a Kubernetes service, this corresponds to the Service.ports[].name.
+                        Name must either be an empty string or pass DNS_LABEL validation:
+                        * must be no more than 63 characters long.
+                        * must consist of lower case alphanumeric characters or '-'.
+                        * must start and end with an alphanumeric character.
+                        Default is empty string.
                       type: string
                     port:
-                      description: port represents the port number of the endpoint.
-                        If this is not specified, ports are not restricted and must
-                        be interpreted in the context of the specific consumer.
+                      description: |-
+                        port represents the port number of the endpoint.
+                        If this is not specified, ports are not restricted and must be
+                        interpreted in the context of the specific consumer.
                       format: int32
                       type: integer
                     protocol:
                       default: TCP
-                      description: protocol represents the IP protocol for this port.
-                        Must be UDP, TCP, or SCTP. Default is TCP.
+                      description: |-
+                        protocol represents the IP protocol for this port.
+                        Must be UDP, TCP, or SCTP.
+                        Default is TCP.
                       type: string
                   type: object
+                  x-kubernetes-map-type: atomic
                 type: array
                 x-kubernetes-list-type: atomic
             required:
@@ -191,9 +207,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/networking.fleet.azure.com_endpointsliceimports.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_endpointsliceimports.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: endpointsliceimports.networking.fleet.azure.com
 spec:
   group: networking.fleet.azure.com
@@ -21,18 +19,24 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: EndpointSliceImport is a data transport type that hub cluster
-          uses to distribute exported EndpointSlices to member clusters.
+        description: |-
+          EndpointSliceImport is a data transport type that hub cluster uses to distribute exported EndpointSlices
+          to member clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -42,7 +46,8 @@ spec:
             properties:
               addressType:
                 default: IPv4
-                description: The type of addresses carried by this EndpointSliceExport.
+                description: |-
+                  The type of addresses carried by this EndpointSliceExport.
                   At this stage only IPv4 addresses are supported.
                 enum:
                 - IPv4
@@ -57,9 +62,9 @@ spec:
                     description: The ID of the cluster where the object is exported.
                     type: string
                   exportedSince:
-                    description: The timestamp from a local clock when the generation
-                      of the object is exported. This field is marked as optional
-                      for backwards compatibility reasons.
+                    description: |-
+                      The timestamp from a local clock when the generation of the object is exported.
+                      This field is marked as optional for backwards compatibility reasons.
                     format: date-time
                     type: string
                   generation:
@@ -94,6 +99,7 @@ spec:
                 - resourceVersion
                 - uid
                 type: object
+                x-kubernetes-map-type: atomic
               endpoints:
                 description: A list of unique endpoints in the exported EndpointSlice.
                 items:
@@ -101,10 +107,11 @@ spec:
                     backend.
                   properties:
                     addresses:
-                      description: Addresses of the Endpoint. Addresses should be
-                        interpreted per its owner EndpointSliceExport's addressType
-                        field. This field contains at least one address and at maximum
-                        100; for more information about this constraint, see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#endpoint-v1beta1-discovery-k8s-io.
+                      description: |-
+                        Addresses of the Endpoint.
+                        Addresses should be interpreted per its owner EndpointSliceExport's addressType field. This field contains
+                        at least one address and at maximum 100; for more information about this constraint,
+                        see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#endpoint-v1beta1-discovery-k8s-io.
                       items:
                         type: string
                       type: array
@@ -131,51 +138,60 @@ spec:
                 - namespacedName
                 type: object
               ports:
-                description: The list of ports exported by each endpoint in this EndpointSliceExport.
-                  Each port must have a unique name. When the field is empty, it indicates
-                  that there are no defined ports. When a port is defined with a nil
-                  port value, it indicates that all ports are exported. Each slice
-                  may include a maximum of 100 ports.
+                description: |-
+                  The list of ports exported by each endpoint in this EndpointSliceExport. Each port must have a unique name.
+                  When the field is empty, it indicates that there are no defined ports. When a port is defined with a nil
+                  port value, it indicates that all ports are exported. Each slice may include a maximum of 100 ports.
                 items:
                   description: EndpointPort represents a Port used by an EndpointSlice
                   properties:
                     appProtocol:
-                      description: "The application protocol for this port. This is
-                        used as a hint for implementations to offer richer behavior
-                        for protocols that they understand. This field follows standard
-                        Kubernetes label syntax. Valid values are either: \n * Un-prefixed
-                        protocol names - reserved for IANA standard service names
-                        (as per RFC-6335 and https://www.iana.org/assignments/service-names).
-                        \n * Kubernetes-defined prefixed names:   * 'kubernetes.io/h2c'
-                        - HTTP/2 over cleartext as described in https://www.rfc-editor.org/rfc/rfc7540
-                        \  * 'kubernetes.io/ws'  - WebSocket over cleartext as described
-                        in https://www.rfc-editor.org/rfc/rfc6455   * 'kubernetes.io/wss'
-                        - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
-                        \n * Other protocols should use implementation-defined prefixed
-                        names such as mycompany.com/my-custom-protocol."
+                      description: |-
+                        The application protocol for this port.
+                        This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                        This field follows standard Kubernetes label syntax.
+                        Valid values are either:
+
+
+                        * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                        RFC-6335 and https://www.iana.org/assignments/service-names).
+
+
+                        * Kubernetes-defined prefixed names:
+                          * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                          * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                          * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+
+                        * Other protocols should use implementation-defined prefixed names such as
+                        mycompany.com/my-custom-protocol.
                       type: string
                     name:
-                      description: 'name represents the name of this port. All ports
-                        in an EndpointSlice must have a unique name. If the EndpointSlice
-                        is dervied from a Kubernetes service, this corresponds to
-                        the Service.ports[].name. Name must either be an empty string
-                        or pass DNS_LABEL validation: * must be no more than 63 characters
-                        long. * must consist of lower case alphanumeric characters
-                        or ''-''. * must start and end with an alphanumeric character.
-                        Default is empty string.'
+                      description: |-
+                        name represents the name of this port. All ports in an EndpointSlice must have a unique name.
+                        If the EndpointSlice is derived from a Kubernetes service, this corresponds to the Service.ports[].name.
+                        Name must either be an empty string or pass DNS_LABEL validation:
+                        * must be no more than 63 characters long.
+                        * must consist of lower case alphanumeric characters or '-'.
+                        * must start and end with an alphanumeric character.
+                        Default is empty string.
                       type: string
                     port:
-                      description: port represents the port number of the endpoint.
-                        If this is not specified, ports are not restricted and must
-                        be interpreted in the context of the specific consumer.
+                      description: |-
+                        port represents the port number of the endpoint.
+                        If this is not specified, ports are not restricted and must be
+                        interpreted in the context of the specific consumer.
                       format: int32
                       type: integer
                     protocol:
                       default: TCP
-                      description: protocol represents the IP protocol for this port.
-                        Must be UDP, TCP, or SCTP. Default is TCP.
+                      description: |-
+                        protocol represents the IP protocol for this port.
+                        Must be UDP, TCP, or SCTP.
+                        Default is TCP.
                       type: string
                   type: object
+                  x-kubernetes-map-type: atomic
                 type: array
                 x-kubernetes-list-type: atomic
             required:
@@ -189,9 +205,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/networking.fleet.azure.com_internalserviceexports.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_internalserviceexports.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: internalserviceexports.networking.fleet.azure.com
 spec:
   group: networking.fleet.azure.com
@@ -23,24 +21,31 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: InternalServiceExport is a data transport type that member clusters
-          in the fleet use to upload the spec of exported Service to the hub cluster.
+        description: |-
+          InternalServiceExport is a data transport type that member clusters in the fleet use to upload the spec of
+          exported Service to the hub cluster.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: InternalServiceExportSpec specifies the spec of an exported
-              Service; at this stage only the ports of an exported Service are sync'd.
+            description: |-
+              InternalServiceExportSpec specifies the spec of an exported Service; at this stage only the ports of an
+              exported Service are sync'd.
             properties:
               ports:
                 description: A list of ports exposed by the exported Service.
@@ -49,19 +54,21 @@ spec:
                     is exposed.
                   properties:
                     appProtocol:
-                      description: The application protocol for this port. This field
-                        follows standard Kubernetes label syntax. Un-prefixed names
-                        are reserved for IANA standard service names (as per RFC-6335
-                        and http://www.iana.org/assignments/service-names). Non-standard
-                        protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                      description: |-
+                        The application protocol for this port.
+                        This field follows standard Kubernetes label syntax.
+                        Un-prefixed names are reserved for IANA standard service names (as per
+                        RFC-6335 and http://www.iana.org/assignments/service-names).
+                        Non-standard protocols should use prefixed names such as
+                        mycompany.com/my-custom-protocol.
                         Field can be enabled with ServiceAppProtocol feature gate.
                       type: string
                     name:
-                      description: The name of this port within the service. This
-                        must be a DNS_LABEL. All ports within a ServiceSpec must have
-                        unique names. When considering the endpoints for a Service,
-                        this must match the 'name' field in the EndpointPort. Optional
-                        if only one ServicePort is defined on this service.
+                      description: |-
+                        The name of this port within the service. This must be a DNS_LABEL.
+                        All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service,
+                        this must match the 'name' field in the EndpointPort.
+                        Optional if only one ServicePort is defined on this service.
                       type: string
                     port:
                       description: The port that will be exposed by this service.
@@ -71,8 +78,9 @@ spec:
                       type: integer
                     protocol:
                       default: TCP
-                      description: The IP protocol for this port. Supports "TCP",
-                        "UDP", and "SCTP". Default is TCP.
+                      description: |-
+                        The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                        Default is TCP.
                       enum:
                       - TCP
                       - UDP
@@ -100,9 +108,9 @@ spec:
                     description: The ID of the cluster where the object is exported.
                     type: string
                   exportedSince:
-                    description: The timestamp from a local clock when the generation
-                      of the object is exported. This field is marked as optional
-                      for backwards compatibility reasons.
+                    description: |-
+                      The timestamp from a local clock when the generation of the object is exported.
+                      This field is marked as optional for backwards compatibility reasons.
                     format: date-time
                     type: string
                   generation:
@@ -137,6 +145,7 @@ spec:
                 - resourceVersion
                 - uid
                 type: object
+                x-kubernetes-map-type: atomic
             required:
             - ports
             - serviceReference
@@ -148,44 +157,42 @@ spec:
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -199,11 +206,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -224,9 +232,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/networking.fleet.azure.com_internalserviceimports.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_internalserviceimports.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: internalserviceimports.networking.fleet.azure.com
 spec:
   group: networking.fleet.azure.com
@@ -23,21 +21,25 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: InternalServiceImport is used by the MCS controller to import
-          the Service to a single cluster manually, while ServiceImport is logical
-          identifiers for a Service that exists in another cluster or that stretches
-          across multiple clusters and it will be automatically created in the hub
-          cluster when exporting service.
+        description: |-
+          InternalServiceImport is used by the MCS controller to import the Service to a single cluster manually,
+          while ServiceImport is logical identifiers for a Service that exists in another cluster or that stretches
+          across multiple clusters and it will be automatically created in the hub cluster when exporting service.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -54,9 +56,9 @@ spec:
                     description: The ID of the cluster where the object is exported.
                     type: string
                   exportedSince:
-                    description: The timestamp from a local clock when the generation
-                      of the object is exported. This field is marked as optional
-                      for backwards compatibility reasons.
+                    description: |-
+                      The timestamp from a local clock when the generation of the object is exported.
+                      This field is marked as optional for backwards compatibility reasons.
                     format: date-time
                     type: string
                   generation:
@@ -91,12 +93,14 @@ spec:
                 - resourceVersion
                 - uid
                 type: object
+                x-kubernetes-map-type: atomic
             required:
             - serviceImportReference
             type: object
           status:
-            description: status contains information about the exported services that
-              form the multi-cluster service referenced by this ServiceImport.
+            description: |-
+              status contains information about the exported services that form
+              the multi-cluster service referenced by this ServiceImport.
             properties:
               clusters:
                 description: clusters is the list of exporting clusters from which
@@ -129,19 +133,21 @@ spec:
                     is exposed.
                   properties:
                     appProtocol:
-                      description: The application protocol for this port. This field
-                        follows standard Kubernetes label syntax. Un-prefixed names
-                        are reserved for IANA standard service names (as per RFC-6335
-                        and http://www.iana.org/assignments/service-names). Non-standard
-                        protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                      description: |-
+                        The application protocol for this port.
+                        This field follows standard Kubernetes label syntax.
+                        Un-prefixed names are reserved for IANA standard service names (as per
+                        RFC-6335 and http://www.iana.org/assignments/service-names).
+                        Non-standard protocols should use prefixed names such as
+                        mycompany.com/my-custom-protocol.
                         Field can be enabled with ServiceAppProtocol feature gate.
                       type: string
                     name:
-                      description: The name of this port within the service. This
-                        must be a DNS_LABEL. All ports within a ServiceSpec must have
-                        unique names. When considering the endpoints for a Service,
-                        this must match the 'name' field in the EndpointPort. Optional
-                        if only one ServicePort is defined on this service.
+                      description: |-
+                        The name of this port within the service. This must be a DNS_LABEL.
+                        All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service,
+                        this must match the 'name' field in the EndpointPort.
+                        Optional if only one ServicePort is defined on this service.
                       type: string
                     port:
                       description: The port that will be exposed by this service.
@@ -151,8 +157,9 @@ spec:
                       type: integer
                     protocol:
                       default: TCP
-                      description: The IP protocol for this port. Supports "TCP",
-                        "UDP", and "SCTP". Default is TCP.
+                      description: |-
+                        The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                        Default is TCP.
                       enum:
                       - TCP
                       - UDP
@@ -171,10 +178,13 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               sessionAffinity:
-                description: 'Supports "ClientIP" and "None". Used to maintain session
-                  affinity. Enable client IP based session affinity. Must be ClientIP
-                  or None. Defaults to None. Ignored when type is Headless More info:
-                  https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                description: |-
+                  Supports "ClientIP" and "None". Used to maintain session affinity.
+                  Enable client IP based session affinity.
+                  Must be ClientIP or None.
+                  Defaults to None.
+                  Ignored when type is Headless
+                  More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                 type: string
               sessionAffinityConfig:
                 description: sessionAffinityConfig contains session affinity configuration.
@@ -184,17 +194,18 @@ spec:
                       based session affinity.
                     properties:
                       timeoutSeconds:
-                        description: timeoutSeconds specifies the seconds of ClientIP
-                          type session sticky time. The value must be >0 && <=86400(for
-                          1 day) if ServiceAffinity == "ClientIP". Default value is
-                          10800(for 3 hours).
+                        description: |-
+                          timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                          The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                          Default value is 10800(for 3 hours).
                         format: int32
                         type: integer
                     type: object
                 type: object
               type:
-                description: type defines the type of this service. Must be ClusterSetIP
-                  or Headless.
+                description: |-
+                  type defines the type of this service.
+                  Must be ClusterSetIP or Headless.
                 enum:
                 - ClusterSetIP
                 - Headless
@@ -207,9 +218,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/networking.fleet.azure.com_multiclusterservices.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_multiclusterservices.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: multiclusterservices.networking.fleet.azure.com
 spec:
   group: networking.fleet.azure.com
@@ -40,14 +38,19 @@ spec:
           load balancer to consume services across clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -75,44 +78,42 @@ spec:
                 description: Current service state
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -126,11 +127,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -146,41 +148,54 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               loadBalancer:
-                description: LoadBalancerStatus represents the status of a load-balancer.
+                description: |-
+                  LoadBalancerStatus represents the status of a load-balancer.
                   if one is present.
                 properties:
                   ingress:
-                    description: Ingress is a list containing ingress points for the
-                      load-balancer. Traffic intended for the service should be sent
-                      to these ingress points.
+                    description: |-
+                      Ingress is a list containing ingress points for the load-balancer.
+                      Traffic intended for the service should be sent to these ingress points.
                     items:
-                      description: 'LoadBalancerIngress represents the status of a
-                        load-balancer ingress point: traffic intended for the service
-                        should be sent to an ingress point.'
+                      description: |-
+                        LoadBalancerIngress represents the status of a load-balancer ingress point:
+                        traffic intended for the service should be sent to an ingress point.
                       properties:
                         hostname:
-                          description: Hostname is set for load-balancer ingress points
-                            that are DNS based (typically AWS load-balancers)
+                          description: |-
+                            Hostname is set for load-balancer ingress points that are DNS based
+                            (typically AWS load-balancers)
                           type: string
                         ip:
-                          description: IP is set for load-balancer ingress points
-                            that are IP based (typically GCE or OpenStack load-balancers)
+                          description: |-
+                            IP is set for load-balancer ingress points that are IP based
+                            (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ipMode:
+                          description: |-
+                            IPMode specifies how the load-balancer IP behaves, and may only be specified when the ip field is specified.
+                            Setting this to "VIP" indicates that traffic is delivered to the node with
+                            the destination set to the load-balancer's IP and port.
+                            Setting this to "Proxy" indicates that traffic is delivered to the node or pod with
+                            the destination set to the node's IP and node port or the pod's IP and port.
+                            Service implementations may use this information to adjust traffic routing.
                           type: string
                         ports:
-                          description: Ports is a list of records of service ports
-                            If used, every port defined in the service should have
-                            an entry in it
+                          description: |-
+                            Ports is a list of records of service ports
+                            If used, every port defined in the service should have an entry in it
                           items:
                             properties:
                               error:
-                                description: 'Error is to record the problem with
-                                  the service port The format of the error shall comply
-                                  with the following rules: - built-in error values
-                                  shall be specified in this file and those shall
-                                  use   CamelCase names - cloud provider specific
-                                  error values must have names that comply with the   format
-                                  foo.example.com/CamelCase. --- The regex it matches
-                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                description: |-
+                                  Error is to record the problem with the service port
+                                  The format of the error shall comply with the following rules:
+                                  - built-in error values shall be specified in this file and those shall use
+                                    CamelCase names
+                                  - cloud provider specific error values must have names that comply with the
+                                    format foo.example.com/CamelCase.
+                                  ---
+                                  The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                                 maxLength: 316
                                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                                 type: string
@@ -191,9 +206,9 @@ spec:
                                 type: integer
                               protocol:
                                 default: TCP
-                                description: 'Protocol is the protocol of the service
-                                  port of which status is recorded here The supported
-                                  values are: "TCP", "UDP", "SCTP"'
+                                description: |-
+                                  Protocol is the protocol of the service port of which status is recorded here
+                                  The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
                             - port
@@ -203,6 +218,7 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                 type: object
             type: object
         required:
@@ -212,9 +228,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/networking.fleet.azure.com_serviceexports.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_serviceexports.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: serviceexports.networking.fleet.azure.com
 spec:
   group: networking.fleet.azure.com
@@ -37,14 +35,19 @@ spec:
           exported to other clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -54,44 +57,42 @@ spec:
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -105,11 +106,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -130,9 +132,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/networking.fleet.azure.com_serviceimports.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_serviceimports.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: serviceimports.networking.fleet.azure.com
 spec:
   group: networking.fleet.azure.com
@@ -27,20 +25,26 @@ spec:
           ClusterSet.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           status:
-            description: status contains information about the exported services that
-              form the multi-cluster service referenced by this ServiceImport.
+            description: |-
+              status contains information about the exported services that form
+              the multi-cluster service referenced by this ServiceImport.
             properties:
               clusters:
                 description: clusters is the list of exporting clusters from which
@@ -73,19 +77,21 @@ spec:
                     is exposed.
                   properties:
                     appProtocol:
-                      description: The application protocol for this port. This field
-                        follows standard Kubernetes label syntax. Un-prefixed names
-                        are reserved for IANA standard service names (as per RFC-6335
-                        and http://www.iana.org/assignments/service-names). Non-standard
-                        protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                      description: |-
+                        The application protocol for this port.
+                        This field follows standard Kubernetes label syntax.
+                        Un-prefixed names are reserved for IANA standard service names (as per
+                        RFC-6335 and http://www.iana.org/assignments/service-names).
+                        Non-standard protocols should use prefixed names such as
+                        mycompany.com/my-custom-protocol.
                         Field can be enabled with ServiceAppProtocol feature gate.
                       type: string
                     name:
-                      description: The name of this port within the service. This
-                        must be a DNS_LABEL. All ports within a ServiceSpec must have
-                        unique names. When considering the endpoints for a Service,
-                        this must match the 'name' field in the EndpointPort. Optional
-                        if only one ServicePort is defined on this service.
+                      description: |-
+                        The name of this port within the service. This must be a DNS_LABEL.
+                        All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service,
+                        this must match the 'name' field in the EndpointPort.
+                        Optional if only one ServicePort is defined on this service.
                       type: string
                     port:
                       description: The port that will be exposed by this service.
@@ -95,8 +101,9 @@ spec:
                       type: integer
                     protocol:
                       default: TCP
-                      description: The IP protocol for this port. Supports "TCP",
-                        "UDP", and "SCTP". Default is TCP.
+                      description: |-
+                        The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                        Default is TCP.
                       enum:
                       - TCP
                       - UDP
@@ -115,10 +122,13 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               sessionAffinity:
-                description: 'Supports "ClientIP" and "None". Used to maintain session
-                  affinity. Enable client IP based session affinity. Must be ClientIP
-                  or None. Defaults to None. Ignored when type is Headless More info:
-                  https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                description: |-
+                  Supports "ClientIP" and "None". Used to maintain session affinity.
+                  Enable client IP based session affinity.
+                  Must be ClientIP or None.
+                  Defaults to None.
+                  Ignored when type is Headless
+                  More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                 type: string
               sessionAffinityConfig:
                 description: sessionAffinityConfig contains session affinity configuration.
@@ -128,17 +138,18 @@ spec:
                       based session affinity.
                     properties:
                       timeoutSeconds:
-                        description: timeoutSeconds specifies the seconds of ClientIP
-                          type session sticky time. The value must be >0 && <=86400(for
-                          1 day) if ServiceAffinity == "ClientIP". Default value is
-                          10800(for 3 hours).
+                        description: |-
+                          timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                          The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                          Default value is 10800(for 3 hours).
                         format: int32
                         type: integer
                     type: object
                 type: object
               type:
-                description: type defines the type of this service. Must be ClusterSetIP
-                  or Headless.
+                description: |-
+                  type defines the type of this service.
+                  Must be ClusterSetIP or Headless.
                 enum:
                 - ClusterSetIP
                 - Headless
@@ -149,9 +160,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,9 +1,7 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:
@@ -25,6 +23,22 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - cluster.kubernetes-fleet.io
+  resources:
+  - internalmemberclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.kubernetes-fleet.io
+  resources:
+  - internalmemberclusters/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - discovery.k8s.io
   resources:

--- a/examples/getting-started/charts/hub/templates/rbac.yaml
+++ b/examples/getting-started/charts/hub/templates/rbac.yaml
@@ -34,6 +34,22 @@ rules:
   - fleet.azure.com
   resources: ["*"]
   verbs: ["*"]
+- apiGroups:
+    - cluster.kubernetes-fleet.io
+  resources:
+    - internalmemberclusters
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - cluster.kubernetes-fleet.io
+  resources:
+    - internalmemberclusters/status
+  verbs:
+    - get
+    - patch
+    - update
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/controllers/member/internalmembercluster/v1beta1/controller_v1beta1.go
+++ b/pkg/controllers/member/internalmembercluster/v1beta1/controller_v1beta1.go
@@ -40,8 +40,8 @@ type Reconciler struct {
 	AgentType    clusterv1beta1.AgentType
 }
 
-//+kubebuilder:rbac:groups=fleet.azure.com,resources=internalmemberclusters,verbs=get;list;watch
-//+kubebuilder:rbac:groups=fleet.azure.com,resources=internalmemberclusters/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=cluster.kubernetes-fleet.io,resources=internalmemberclusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups=cluster.kubernetes-fleet.io,resources=internalmemberclusters/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=networking.fleet.azure.com,resources=multiclusterservices,verbs=get;list;delete
 //+kubebuilder:rbac:groups=networking.fleet.azure.com,resources=serviceexports,verbs=get;list;delete
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,7 +18,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
-	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
+	fleetv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 
 	fleetnetv1alpha1 "go.goms.io/fleet-networking/api/v1alpha1"
 	"go.goms.io/fleet-networking/test/e2e/framework"
@@ -40,7 +40,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(fleetnetv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(fleetv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(fleetv1beta1.AddToScheme(scheme))
 }
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/join_test.go
+++ b/test/e2e/join_test.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
+	fleetv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 
 	fleetnetv1alpha1 "go.goms.io/fleet-networking/api/v1alpha1"
 	"go.goms.io/fleet-networking/test/e2e/framework"
@@ -31,12 +31,12 @@ var _ = Describe("Test Join/Leave workflow", Serial, Ordered, func() {
 		memberClusterName      = memberClusterNames[0]
 		memberClusterNamespace = "fleet-member-" + memberClusterName
 		imcKey                 = types.NamespacedName{Namespace: memberClusterNamespace, Name: memberClusterName}
-		imc                    fleetv1alpha1.InternalMemberCluster
+		imc                    fleetv1beta1.InternalMemberCluster
 		memberCluster          *framework.Cluster
 		cmpOptions             = []cmp.Option{
-			cmpopts.IgnoreFields(fleetv1alpha1.AgentStatus{}, "LastReceivedHeartbeat"),
+			cmpopts.IgnoreFields(fleetv1beta1.AgentStatus{}, "LastReceivedHeartbeat"),
 			cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "ObservedGeneration"),
-			cmpopts.SortSlices(func(status1, status2 fleetv1alpha1.AgentStatus) bool { return status1.Type < status2.Type }),
+			cmpopts.SortSlices(func(status1, status2 fleetv1beta1.AgentStatus) bool { return status1.Type < status2.Type }),
 		}
 	)
 	const (
@@ -47,13 +47,13 @@ var _ = Describe("Test Join/Leave workflow", Serial, Ordered, func() {
 		BeforeEach(func() {
 			By("Creating internalMemberCluster")
 			ctx = context.Background()
-			imc = fleetv1alpha1.InternalMemberCluster{
+			imc = fleetv1beta1.InternalMemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      memberClusterName,
 					Namespace: memberClusterNamespace,
 				},
-				Spec: fleetv1alpha1.InternalMemberClusterSpec{
-					State:                  fleetv1alpha1.ClusterStateJoin,
+				Spec: fleetv1beta1.InternalMemberClusterSpec{
+					State:                  fleetv1beta1.ClusterStateJoin,
 					HeartbeatPeriodSeconds: int32(heartbeatPeriod),
 				},
 			}
@@ -75,22 +75,22 @@ var _ = Describe("Test Join/Leave workflow", Serial, Ordered, func() {
 				if err := hubCluster.Client().Get(ctx, imcKey, &imc); err != nil {
 					return err.Error()
 				}
-				want := []fleetv1alpha1.AgentStatus{
+				want := []fleetv1beta1.AgentStatus{
 					{
-						Type: fleetv1alpha1.MultiClusterServiceAgent,
+						Type: fleetv1beta1.MultiClusterServiceAgent,
 						Conditions: []metav1.Condition{
 							{
-								Type:   string(fleetv1alpha1.AgentJoined),
+								Type:   string(fleetv1beta1.AgentJoined),
 								Status: metav1.ConditionTrue,
 								Reason: "AgentJoined",
 							},
 						},
 					},
 					{
-						Type: fleetv1alpha1.ServiceExportImportAgent,
+						Type: fleetv1beta1.ServiceExportImportAgent,
 						Conditions: []metav1.Condition{
 							{
-								Type:   string(fleetv1alpha1.AgentJoined),
+								Type:   string(fleetv1beta1.AgentJoined),
 								Status: metav1.ConditionTrue,
 								Reason: "AgentJoined",
 							},
@@ -131,7 +131,7 @@ var _ = Describe("Test Join/Leave workflow", Serial, Ordered, func() {
 				if err := hubCluster.Client().Get(ctx, imcKey, &imc); err != nil {
 					return err
 				}
-				imc.Spec.State = fleetv1alpha1.ClusterStateLeave
+				imc.Spec.State = fleetv1beta1.ClusterStateLeave
 				return hubCluster.Client().Update(ctx, &imc)
 			}, framework.PollTimeout, framework.PollInterval).Should(Succeed(), "Failed to update internalMemberCluster spec")
 
@@ -140,22 +140,22 @@ var _ = Describe("Test Join/Leave workflow", Serial, Ordered, func() {
 				if err := hubCluster.Client().Get(ctx, imcKey, &imc); err != nil {
 					return err.Error()
 				}
-				want := []fleetv1alpha1.AgentStatus{
+				want := []fleetv1beta1.AgentStatus{
 					{
-						Type: fleetv1alpha1.MultiClusterServiceAgent,
+						Type: fleetv1beta1.MultiClusterServiceAgent,
 						Conditions: []metav1.Condition{
 							{
-								Type:   string(fleetv1alpha1.AgentJoined),
+								Type:   string(fleetv1beta1.AgentJoined),
 								Status: metav1.ConditionFalse,
 								Reason: "AgentLeft",
 							},
 						},
 					},
 					{
-						Type: fleetv1alpha1.ServiceExportImportAgent,
+						Type: fleetv1beta1.ServiceExportImportAgent,
 						Conditions: []metav1.Condition{
 							{
-								Type:   string(fleetv1alpha1.AgentJoined),
+								Type:   string(fleetv1beta1.AgentJoined),
 								Status: metav1.ConditionFalse,
 								Reason: "AgentLeft",
 							},
@@ -192,7 +192,7 @@ var _ = Describe("Test Join/Leave workflow", Serial, Ordered, func() {
 				if err := hubCluster.Client().Get(ctx, imcKey, &imc); err != nil {
 					return err
 				}
-				imc.Spec.State = fleetv1alpha1.ClusterStateLeave
+				imc.Spec.State = fleetv1beta1.ClusterStateLeave
 				return hubCluster.Client().Update(ctx, &imc)
 			}, framework.PollTimeout, framework.PollInterval).Should(Succeed(), "Failed to update internalMemberCluster spec")
 
@@ -201,22 +201,22 @@ var _ = Describe("Test Join/Leave workflow", Serial, Ordered, func() {
 				if err := hubCluster.Client().Get(ctx, imcKey, &imc); err != nil {
 					return err.Error()
 				}
-				want := []fleetv1alpha1.AgentStatus{
+				want := []fleetv1beta1.AgentStatus{
 					{
-						Type: fleetv1alpha1.MultiClusterServiceAgent,
+						Type: fleetv1beta1.MultiClusterServiceAgent,
 						Conditions: []metav1.Condition{
 							{
-								Type:   string(fleetv1alpha1.AgentJoined),
+								Type:   string(fleetv1beta1.AgentJoined),
 								Status: metav1.ConditionFalse,
 								Reason: "AgentLeft",
 							},
 						},
 					},
 					{
-						Type: fleetv1alpha1.ServiceExportImportAgent,
+						Type: fleetv1beta1.ServiceExportImportAgent,
 						Conditions: []metav1.Condition{
 							{
-								Type:   string(fleetv1alpha1.AgentJoined),
+								Type:   string(fleetv1beta1.AgentJoined),
 								Status: metav1.ConditionFalse,
 								Reason: "AgentLeft",
 							},
@@ -238,7 +238,7 @@ var _ = Describe("Test Join/Leave workflow", Serial, Ordered, func() {
 				if err := hubCluster.Client().Get(ctx, imcKey, &imc); err != nil {
 					return err
 				}
-				imc.Spec.State = fleetv1alpha1.ClusterStateLeave
+				imc.Spec.State = fleetv1beta1.ClusterStateLeave
 				return hubCluster.Client().Update(ctx, &imc)
 			}, framework.PollTimeout, framework.PollInterval).Should(Succeed(), "Failed to update internalMemberCluster spec")
 
@@ -247,22 +247,22 @@ var _ = Describe("Test Join/Leave workflow", Serial, Ordered, func() {
 				if err := hubCluster.Client().Get(ctx, imcKey, &imc); err != nil {
 					return err.Error()
 				}
-				want := []fleetv1alpha1.AgentStatus{
+				want := []fleetv1beta1.AgentStatus{
 					{
-						Type: fleetv1alpha1.MultiClusterServiceAgent,
+						Type: fleetv1beta1.MultiClusterServiceAgent,
 						Conditions: []metav1.Condition{
 							{
-								Type:   string(fleetv1alpha1.AgentJoined),
+								Type:   string(fleetv1beta1.AgentJoined),
 								Status: metav1.ConditionFalse,
 								Reason: "AgentLeft",
 							},
 						},
 					},
 					{
-						Type: fleetv1alpha1.ServiceExportImportAgent,
+						Type: fleetv1beta1.ServiceExportImportAgent,
 						Conditions: []metav1.Condition{
 							{
-								Type:   string(fleetv1alpha1.AgentJoined),
+								Type:   string(fleetv1beta1.AgentJoined),
 								Status: metav1.ConditionFalse,
 								Reason: "AgentLeft",
 							},
@@ -277,7 +277,7 @@ var _ = Describe("Test Join/Leave workflow", Serial, Ordered, func() {
 				if err := hubCluster.Client().Get(ctx, imcKey, &imc); err != nil {
 					return err
 				}
-				imc.Spec.State = fleetv1alpha1.ClusterStateJoin
+				imc.Spec.State = fleetv1beta1.ClusterStateJoin
 				return hubCluster.Client().Update(ctx, &imc)
 			}, framework.PollTimeout, framework.PollInterval).Should(Succeed(), "Failed to update internalMemberCluster spec")
 
@@ -285,22 +285,22 @@ var _ = Describe("Test Join/Leave workflow", Serial, Ordered, func() {
 				if err := hubCluster.Client().Get(ctx, imcKey, &imc); err != nil {
 					return err.Error()
 				}
-				want := []fleetv1alpha1.AgentStatus{
+				want := []fleetv1beta1.AgentStatus{
 					{
-						Type: fleetv1alpha1.MultiClusterServiceAgent,
+						Type: fleetv1beta1.MultiClusterServiceAgent,
 						Conditions: []metav1.Condition{
 							{
-								Type:   string(fleetv1alpha1.AgentJoined),
+								Type:   string(fleetv1beta1.AgentJoined),
 								Status: metav1.ConditionTrue,
 								Reason: "AgentJoined",
 							},
 						},
 					},
 					{
-						Type: fleetv1alpha1.ServiceExportImportAgent,
+						Type: fleetv1beta1.ServiceExportImportAgent,
 						Conditions: []metav1.Condition{
 							{
-								Type:   string(fleetv1alpha1.AgentJoined),
+								Type:   string(fleetv1beta1.AgentJoined),
 								Status: metav1.ConditionTrue,
 								Reason: "AgentJoined",
 							},

--- a/test/scripts/bootstrap.sh
+++ b/test/scripts/bootstrap.sh
@@ -168,7 +168,7 @@ fi
 kubectl config use-context $HUB_CLUSTER-admin
 # need to make sure the version matches the one in the go.mod
 # workaround mentioned in https://github.com/kubernetes-sigs/controller-runtime/issues/1191
-kubectl apply -f `go env GOPATH`/pkg/mod/go.goms.io/fleet@v0.10.5/config/crd/bases/fleet.azure.com_internalmemberclusters.yaml
+kubectl apply -f `go env GOPATH`/pkg/mod/go.goms.io/fleet@v0.10.5/config/crd/bases/cluster.kubernetes-fleet.io_internalmemberclusters.yaml
 kubectl apply -f config/crd/*
 helm install hub-net-controller-manager \
     ./charts/hub-net-controller-manager/ \


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
- Test v1beta1 imc instead of v1alpha1
- Use v1beta1 fleet api by default
- Regenerate the CRD by using new controller-gen

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] run `make reviewable` for basic local test
- [ ] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested
Validated the changes in my local

```
Ran 22 of 22 Specs in 604.438 seconds
SUCCESS! -- 22 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestE2E (604.44s)
PASS
ok      go.goms.io/fleet-networking/test/e2e    604.457s
```

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
