### PR TITLE
interface: add the default value for profile api

### DIFF
--- a/api/v1alpha1/trafficmanagerbackend_types.go
+++ b/api/v1alpha1/trafficmanagerbackend_types.go
@@ -118,7 +118,7 @@ const (
 	//
 	// * "Invalid"
 	// * "Pending"
-	TrafficManagerBackendConditionAccepted TrafficManagerBackendConditionReason = "Accepted"
+	TrafficManagerBackendConditionAccepted TrafficManagerBackendConditionType = "Accepted"
 
 	// TrafficManagerBackendReasonAccepted is used with the "Accepted" condition when the condition is True.
 	TrafficManagerBackendReasonAccepted TrafficManagerBackendConditionReason = "Accepted"

--- a/api/v1alpha1/trafficmanagerbackend_types.go
+++ b/api/v1alpha1/trafficmanagerbackend_types.go
@@ -29,14 +29,14 @@ type TrafficManagerBackend struct {
 }
 
 type TrafficManagerBackendSpec struct {
-	// +required
-	// immutable
 	// Which TrafficManagerProfile the backend should be attached to.
+	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.profile is immutable"
 	Profile TrafficManagerProfileRef `json:"profile"`
 
 	// The reference to a backend.
-	// immutable
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.backend is immutable"
 	Backend TrafficManagerBackendRef `json:"backend"`
 
 	// The total weight of endpoints behind the serviceImport when using the 'Weighted' traffic routing method.

--- a/api/v1alpha1/trafficmanagerprofile_types.go
+++ b/api/v1alpha1/trafficmanagerprofile_types.go
@@ -41,19 +41,23 @@ type MonitorConfig struct {
 	// of each endpoint in this profile.
 	// You can specify two values here: 30 seconds (normal probing) and 10 seconds (fast probing).
 	// +optional
+	// +kubebuilder:default=30
 	IntervalInSeconds *int64 `json:"intervalInSeconds,omitempty"`
 
 	// The path relative to the endpoint domain name used to probe for endpoint health.
 	// +optional
+	// +kubebuilder:default="/"
 	Path *string `json:"path,omitempty"`
 
 	// The TCP port used to probe for endpoint health.
 	// +optional
+	// +kubebuilder:default=80
 	Port *int64 `json:"port,omitempty"`
 
 	// The protocol (HTTP, HTTPS or TCP) used to probe for endpoint health.
 	// +kubebuilder:validation:Enum=HTTP;HTTPS;TCP
 	// +optional
+	// +kubebuilder:default="HTTP"
 	Protocol *TrafficManagerMonitorProtocol `json:"protocol,omitempty"`
 
 	// The monitor timeout for endpoints in this profile. This is the time that Traffic Manager allows endpoints in this profile
@@ -70,6 +74,7 @@ type MonitorConfig struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=9
+	// +kubebuilder:default=3
 	ToleratedNumberOfFailures *int64 `json:"toleratedNumberOfFailures,omitempty"`
 }
 
@@ -86,7 +91,7 @@ type TrafficManagerProfileStatus struct {
 	// DNSName is the fully-qualified domain name (FQDN) of the Traffic Manager profile.
 	// It consists of profile name and the DNS domain name used by Azure Traffic Manager to form the fully-qualified
 	// domain name (FQDN) of the profile.
-	// For example, "<TrafficManagerProfileName>.trafficmanager.net"
+	// For example, "<TrafficManagerProfileNamespace>-<TrafficManagerProfileName>.trafficmanager.net"
 	// +optional
 	DNSName *string `json:"dnsName,omitempty"`
 

--- a/config/crd/bases/networking.fleet.azure.com_trafficmanagerbackends.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_trafficmanagerbackends.yaml
@@ -64,9 +64,7 @@ spec:
             description: The desired state of TrafficManagerBackend.
             properties:
               backend:
-                description: |-
-                  The reference to a backend.
-                  immutable
+                description: The reference to a backend.
                 properties:
                   name:
                     description: Name is the reference to the ServiceImport in the
@@ -75,10 +73,12 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: spec.backend is immutable
+                  rule: self == oldSelf
               profile:
-                description: |-
-                  immutable
-                  Which TrafficManagerProfile the backend should be attached to.
+                description: Which TrafficManagerProfile the backend should be attached
+                  to.
                 properties:
                   name:
                     description: Name is the name of the referenced trafficManagerProfile.
@@ -86,6 +86,9 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: spec.profile is immutable
+                  rule: self == oldSelf
               weight:
                 description: |-
                   The total weight of endpoints behind the serviceImport when using the 'Weighted' traffic routing method.

--- a/config/crd/bases/networking.fleet.azure.com_trafficmanagerprofiles.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_trafficmanagerprofiles.yaml
@@ -60,6 +60,7 @@ spec:
                   profile.
                 properties:
                   intervalInSeconds:
+                    default: 30
                     description: |-
                       The monitor interval for endpoints in this profile. This is the interval at which Traffic Manager will check the health
                       of each endpoint in this profile.
@@ -67,14 +68,17 @@ spec:
                     format: int64
                     type: integer
                   path:
+                    default: /
                     description: The path relative to the endpoint domain name used
                       to probe for endpoint health.
                     type: string
                   port:
+                    default: 80
                     description: The TCP port used to probe for endpoint health.
                     format: int64
                     type: integer
                   protocol:
+                    default: HTTP
                     description: The protocol (HTTP, HTTPS or TCP) used to probe for
                       endpoint health.
                     enum:
@@ -93,6 +97,7 @@ spec:
                     format: int64
                     type: integer
                   toleratedNumberOfFailures:
+                    default: 3
                     description: |-
                       The number of consecutive failed health check that Traffic Manager tolerates before declaring an endpoint in this profile
                       Degraded after the next failed health check.
@@ -183,7 +188,7 @@ spec:
                   DNSName is the fully-qualified domain name (FQDN) of the Traffic Manager profile.
                   It consists of profile name and the DNS domain name used by Azure Traffic Manager to form the fully-qualified
                   domain name (FQDN) of the profile.
-                  For example, "<TrafficManagerProfileName>.trafficmanager.net"
+                  For example, "<TrafficManagerProfileNamespace>-<TrafficManagerProfileName>.trafficmanager.net"
                 type: string
             type: object
         required:


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:

In order to reduce the Azure update call, we need to know the default value of the profile configuration when comparing the profile spec with the azure profile resource.

It's better to define them in the API itself.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] run `make reviewable` for basic local test
- [ ] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to be tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
