### PR TITLE
feat: create defaulter func for trafficManagerProfile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/apimachinery v0.30.2
 	k8s.io/client-go v0.30.2
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 	sigs.k8s.io/controller-runtime v0.18.4
 )
 
@@ -70,7 +71,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.30.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20240620174524-b456828f718b // indirect
-	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/pkg/common/defaulter/trafficmanagerprofile.go
+++ b/pkg/common/defaulter/trafficmanagerprofile.go
@@ -1,0 +1,49 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+// Package defaulter provides the utils for setting default values for a resource.
+package defaulter
+
+import (
+	"k8s.io/utils/ptr"
+
+	fleetnetv1alpha1 "go.goms.io/fleet-networking/api/v1alpha1"
+)
+
+// SetDefaultsTrafficManagerProfile sets the default values for TrafficManagerProfile.
+func SetDefaultsTrafficManagerProfile(obj *fleetnetv1alpha1.TrafficManagerProfile) {
+	if obj.Spec.MonitorConfig == nil {
+		obj.Spec.MonitorConfig = &fleetnetv1alpha1.MonitorConfig{}
+	}
+
+	if obj.Spec.MonitorConfig.IntervalInSeconds == nil {
+		obj.Spec.MonitorConfig.IntervalInSeconds = ptr.To(int64(30))
+	}
+
+	if obj.Spec.MonitorConfig.Path == nil {
+		obj.Spec.MonitorConfig.Path = ptr.To("/")
+	}
+
+	if obj.Spec.MonitorConfig.Port == nil {
+		obj.Spec.MonitorConfig.Port = ptr.To(int64(80))
+	}
+
+	if obj.Spec.MonitorConfig.Protocol == nil {
+		obj.Spec.MonitorConfig.Protocol = ptr.To(fleetnetv1alpha1.TrafficManagerMonitorProtocolHTTP)
+	}
+
+	// TimeoutInSeconds value depends on the IntervalInSeconds, so that the defaulter MUST handle the IntervalInSeconds first.
+	if obj.Spec.MonitorConfig.TimeoutInSeconds == nil {
+		if *obj.Spec.MonitorConfig.IntervalInSeconds == 30 {
+			obj.Spec.MonitorConfig.TimeoutInSeconds = ptr.To(int64(10))
+		} else { // assuming validation wehbook should validate the  intervalInSeconds first
+			obj.Spec.MonitorConfig.TimeoutInSeconds = ptr.To(int64(9))
+		}
+	}
+
+	if obj.Spec.MonitorConfig.ToleratedNumberOfFailures == nil {
+		obj.Spec.MonitorConfig.ToleratedNumberOfFailures = ptr.To(int64(3))
+	}
+}

--- a/pkg/common/defaulter/trafficmanagerprofile.go
+++ b/pkg/common/defaulter/trafficmanagerprofile.go
@@ -35,10 +35,15 @@ func SetDefaultsTrafficManagerProfile(obj *fleetnetv1alpha1.TrafficManagerProfil
 	}
 
 	// TimeoutInSeconds value depends on the IntervalInSeconds, so that the defaulter MUST handle the IntervalInSeconds first.
+	// * If the Probing Interval is set to 30 seconds, then you can set the Timeout value between 5 and 10 seconds.
+	//   If no value is specified, it uses a default value of 10 seconds.
+	// * If the Probing Interval is set to 10 seconds, then you can set the Timeout value between 5 and 9 seconds.
+	//   If no Timeout value is specified, it uses a default value of 9 seconds.
+	// Reference link: https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-monitoring#configure-endpoint-monitoring
 	if obj.Spec.MonitorConfig.TimeoutInSeconds == nil {
 		if *obj.Spec.MonitorConfig.IntervalInSeconds == 30 {
 			obj.Spec.MonitorConfig.TimeoutInSeconds = ptr.To(int64(10))
-		} else { // assuming validation wehbook should validate the  intervalInSeconds first
+		} else { // assuming validation wehbook should validate the intervalInSeconds first
 			obj.Spec.MonitorConfig.TimeoutInSeconds = ptr.To(int64(9))
 		}
 	}

--- a/pkg/common/defaulter/trafficmanagerprofile_test.go
+++ b/pkg/common/defaulter/trafficmanagerprofile_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package defaulter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/ptr"
+
+	fleetnetv1alpha1 "go.goms.io/fleet-networking/api/v1alpha1"
+)
+
+func TestSetTrafficManagerProfile(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *fleetnetv1alpha1.TrafficManagerProfile
+		want *fleetnetv1alpha1.TrafficManagerProfile
+	}{
+		{
+			name: "TrafficManagerProfile with nil spec",
+			obj: &fleetnetv1alpha1.TrafficManagerProfile{
+				Spec: fleetnetv1alpha1.TrafficManagerProfileSpec{},
+			},
+			want: &fleetnetv1alpha1.TrafficManagerProfile{
+				Spec: fleetnetv1alpha1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1alpha1.MonitorConfig{
+						IntervalInSeconds:         ptr.To(int64(30)),
+						Path:                      ptr.To("/"),
+						Port:                      ptr.To(int64(80)),
+						Protocol:                  ptr.To(fleetnetv1alpha1.TrafficManagerMonitorProtocolHTTP),
+						TimeoutInSeconds:          ptr.To(int64(10)),
+						ToleratedNumberOfFailures: ptr.To(int64(3)),
+					},
+				},
+			},
+		},
+		{
+			name: "TrafficManagerProfile with 10 IntervalInSeconds and nil TimeoutInSeconds",
+			obj: &fleetnetv1alpha1.TrafficManagerProfile{
+				Spec: fleetnetv1alpha1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1alpha1.MonitorConfig{
+						IntervalInSeconds: ptr.To(int64(10)),
+					},
+				},
+			},
+			want: &fleetnetv1alpha1.TrafficManagerProfile{
+				Spec: fleetnetv1alpha1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1alpha1.MonitorConfig{
+						IntervalInSeconds:         ptr.To(int64(10)),
+						Path:                      ptr.To("/"),
+						Port:                      ptr.To(int64(80)),
+						Protocol:                  ptr.To(fleetnetv1alpha1.TrafficManagerMonitorProtocolHTTP),
+						TimeoutInSeconds:          ptr.To(int64(9)),
+						ToleratedNumberOfFailures: ptr.To(int64(3)),
+					},
+				},
+			},
+		},
+		{
+			name: "TrafficManagerProfile with values",
+			obj: &fleetnetv1alpha1.TrafficManagerProfile{
+				Spec: fleetnetv1alpha1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1alpha1.MonitorConfig{
+						IntervalInSeconds:         ptr.To(int64(10)),
+						Path:                      ptr.To("/healthz"),
+						Port:                      ptr.To(int64(8080)),
+						Protocol:                  ptr.To(fleetnetv1alpha1.TrafficManagerMonitorProtocolHTTPS),
+						TimeoutInSeconds:          ptr.To(int64(9)),
+						ToleratedNumberOfFailures: ptr.To(int64(4)),
+					},
+				},
+			},
+			want: &fleetnetv1alpha1.TrafficManagerProfile{
+				Spec: fleetnetv1alpha1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1alpha1.MonitorConfig{
+						IntervalInSeconds:         ptr.To(int64(10)),
+						Path:                      ptr.To("/healthz"),
+						Port:                      ptr.To(int64(8080)),
+						Protocol:                  ptr.To(fleetnetv1alpha1.TrafficManagerMonitorProtocolHTTPS),
+						TimeoutInSeconds:          ptr.To(int64(9)),
+						ToleratedNumberOfFailures: ptr.To(int64(4)),
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			SetDefaultsTrafficManagerProfile(tc.obj)
+			if diff := cmp.Diff(tc.want, tc.obj); diff != "" {
+				t.Errorf("SetDefaultsTrafficManagerProfile() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
It can used by the default webhook or the profile controller.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [X] run `make reviewable` for basic local test
- [X] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests

### How has this code been tested

add unit tests

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
