### PR TITLE
fix: requeue the request when the dns is not assigned

### DIFF
--- a/pkg/common/objectmeta/objectmeta.go
+++ b/pkg/common/objectmeta/objectmeta.go
@@ -51,6 +51,12 @@ const (
 	// ServiceAnnotationLoadBalancerResourceGroup is the annotation used on the service to specify the resource group of
 	// load balancer objects that are not in the same resource group as the cluster.
 	ServiceAnnotationLoadBalancerResourceGroup = "service.beta.kubernetes.io/azure-load-balancer-resource-group"
+
+	// ServiceAnnotationAzureDNSLabelName is the annotation used on the service to Specify the DNS label name for the
+	// service’s public IP address (PIP). If it is set to empty string, DNS in PIP would be deleted. Because of a bug,
+	// before v1.15.10/v1.16.7/v1.17.3, the DNS label on PIP would also be deleted if the annotation is not specified.
+	// https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/
+	ServiceAnnotationAzureDNSLabelName = "service.beta.kubernetes.io/azure-dns-label-name"
 )
 
 // Azure Resource Tags

--- a/pkg/controllers/member/serviceexport/controller.go
+++ b/pkg/controllers/member/serviceexport/controller.go
@@ -312,13 +312,30 @@ func (r *Reconciler) setAzureRelatedInformation(ctx context.Context, service *co
 		return nil
 	}
 	export.Spec.PublicIPResourceID = pip.ID
+
 	// Note the user can set the dns label via the Azure portal or Azure CLI without updating service.
 	// This information may be stale as we don't monitor the public IP address resource.
 	export.Spec.IsDNSLabelConfigured = pip.Properties != nil && pip.Properties.DNSSettings != nil && pip.Properties.DNSSettings.DomainNameLabel != nil
+	dnsName, found := service.Annotations[objectmeta.ServiceAnnotationAzureDNSLabelName]
+	if !found {
+		// cloud provider won't delete DNS label on pip if the annotation is not set.
+		return nil
+	}
+	if len(dnsName) == 0 {
+		export.Spec.IsDNSLabelConfigured = false // cloud provider will delete the DNS label on the pip.
+		return nil
+	}
+	if !export.Spec.IsDNSLabelConfigured {
+		err = fmt.Errorf("in the process of adding DNS to the public ip address %s", *pip.ID)
+		klog.ErrorS(err, "Requeue the request to see if the DNS is ready or not", "service", serviceKObj)
+		return err
+	}
 	return nil
 }
 
 // TODO: can improve the performance by caching the public IP address resource ID.
+// Note: we don't support "service.beta.kubernetes.io/azure-pip-prefix-id" annotation, and public ip cannot be found in
+// this case.
 func (r *Reconciler) lookupPublicIPResourceIDByLoadBalancerIP(ctx context.Context, service *corev1.Service) (*armnetwork.PublicIPAddress, error) {
 	// The customer can specify the resource group for the public IP address in the service annotation.
 	rg := strings.TrimSpace(service.Annotations[objectmeta.ServiceAnnotationLoadBalancerResourceGroup])

--- a/pkg/controllers/member/serviceexport/controller.go
+++ b/pkg/controllers/member/serviceexport/controller.go
@@ -317,6 +317,7 @@ func (r *Reconciler) setAzureRelatedInformation(ctx context.Context, service *co
 	// This information may be stale as we don't monitor the public IP address resource.
 	export.Spec.IsDNSLabelConfigured = pip.Properties != nil && pip.Properties.DNSSettings != nil && pip.Properties.DNSSettings.DomainNameLabel != nil
 	dnsName, found := service.Annotations[objectmeta.ServiceAnnotationAzureDNSLabelName]
+	klog.V(2).InfoS("Finding whether the DNS is assigned", "service", serviceKObj, "dnsName", dnsName, "isSetOnService", found, "isConfiguredOnPIP", export.Spec.IsDNSLabelConfigured)
 	if !found {
 		// cloud provider won't delete DNS label on pip if the annotation is not set.
 		return nil

--- a/pkg/controllers/member/serviceexport/controller.go
+++ b/pkg/controllers/member/serviceexport/controller.go
@@ -316,8 +316,12 @@ func (r *Reconciler) setAzureRelatedInformation(ctx context.Context, service *co
 	// Note the user can set the dns label via the Azure portal or Azure CLI without updating service.
 	// This information may be stale as we don't monitor the public IP address resource.
 	export.Spec.IsDNSLabelConfigured = pip.Properties != nil && pip.Properties.DNSSettings != nil && pip.Properties.DNSSettings.DomainNameLabel != nil
+
+	// No matter if the customer bring your own IP or not, the cloud provider will reconcile the DNS label based on the
+	// DNS annotation.
 	dnsName, found := service.Annotations[objectmeta.ServiceAnnotationAzureDNSLabelName]
 	klog.V(2).InfoS("Finding whether the DNS is assigned", "service", serviceKObj, "dnsName", dnsName, "isSetOnService", found, "isConfiguredOnPIP", export.Spec.IsDNSLabelConfigured)
+	// If the annotation is not set, the cloud provider won't reconcile the DNS label and return the current status.
 	if !found {
 		// cloud provider won't delete DNS label on pip if the annotation is not set.
 		return nil


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

- set whether the DNS label is set correctly based on the dns annotation
- requeue the request when the dns is not ready on the pip


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [X] run `make reviewable` for basic local test
- [ ] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to be tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
