### PR TITLE
feat: support weight 0 for the trafficManagerBackend

### DIFF
--- a/pkg/common/defaulter/trafficmanagerbackend.go
+++ b/pkg/common/defaulter/trafficmanagerbackend.go
@@ -1,0 +1,19 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package defaulter
+
+import (
+	"k8s.io/utils/ptr"
+
+	fleetnetv1beta1 "go.goms.io/fleet-networking/api/v1beta1"
+)
+
+// SetDefaultsTrafficManagerBackend sets the default values for TrafficManagerBackend.
+func SetDefaultsTrafficManagerBackend(obj *fleetnetv1beta1.TrafficManagerBackend) {
+	if obj.Spec.Weight == nil {
+		obj.Spec.Weight = ptr.To(int64(1))
+	}
+}

--- a/pkg/common/defaulter/trafficmanagerbackend_test.go
+++ b/pkg/common/defaulter/trafficmanagerbackend_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package defaulter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/ptr"
+
+	fleetnetv1beta1 "go.goms.io/fleet-networking/api/v1beta1"
+)
+
+func TestSetDefaultsTrafficManagerBackend(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *fleetnetv1beta1.TrafficManagerBackend
+		want *fleetnetv1beta1.TrafficManagerBackend
+	}{
+		{
+			name: "TrafficManagerBackend with nil weight",
+			obj: &fleetnetv1beta1.TrafficManagerBackend{
+				Spec: fleetnetv1beta1.TrafficManagerBackendSpec{},
+			},
+			want: &fleetnetv1beta1.TrafficManagerBackend{
+				Spec: fleetnetv1beta1.TrafficManagerBackendSpec{
+					Weight: ptr.To(int64(1)),
+				},
+			},
+		},
+		{
+			name: "TrafficManagerBackend with values",
+			obj: &fleetnetv1beta1.TrafficManagerBackend{
+				Spec: fleetnetv1beta1.TrafficManagerBackendSpec{
+					Weight: ptr.To(int64(100)),
+				},
+			},
+			want: &fleetnetv1beta1.TrafficManagerBackend{
+				Spec: fleetnetv1beta1.TrafficManagerBackendSpec{
+					Weight: ptr.To(int64(100)),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			SetDefaultsTrafficManagerBackend(tc.obj)
+			if diff := cmp.Diff(tc.want, tc.obj); diff != "" {
+				t.Errorf("SetDefaultsTrafficManagerBackend() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controllers/hub/trafficmanagerbackend/controller.go
+++ b/pkg/controllers/hub/trafficmanagerbackend/controller.go
@@ -122,7 +122,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			return ctrl.Result{}, controller.NewUpdateIgnoreConflictError(err)
 		}
 	}
-	// TODO: replace the following with defaulter wehbook
+	// TODO: replace the following with defaulter webhook
 	defaulter.SetDefaultsTrafficManagerBackend(backend)
 	return r.handleUpdate(ctx, backend)
 }

--- a/pkg/controllers/hub/trafficmanagerbackend/controller_integration_test.go
+++ b/pkg/controllers/hub/trafficmanagerbackend/controller_integration_test.go
@@ -973,6 +973,28 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 			validator.ValidateTrafficManagerBackendConsistently(ctx, k8sClient, &want)
 		})
 
+		It("Updating weight to 0", func() {
+			Expect(k8sClient.Get(ctx, backendNamespacedName, backend)).Should(Succeed(), "failed to get trafficManagerBackend")
+			backend.Spec.Weight = ptr.To(int64(0))
+			Expect(k8sClient.Update(ctx, backend)).Should(Succeed(), "failed to update trafficManagerBackend")
+		})
+
+		It("Validating trafficManagerBackend", func() {
+			want := fleetnetv1beta1.TrafficManagerBackend{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       backendName,
+					Namespace:  testNamespace,
+					Finalizers: []string{objectmeta.TrafficManagerBackendFinalizer},
+				},
+				Spec: backend.Spec,
+				Status: fleetnetv1beta1.TrafficManagerBackendStatus{
+					Conditions: buildTrueCondition(backend.Generation),
+				},
+			}
+			validator.ValidateTrafficManagerBackend(ctx, k8sClient, &want)
+			validator.ValidateTrafficManagerBackendConsistently(ctx, k8sClient, &want)
+		})
+
 		It("Deleting trafficManagerBackend", func() {
 			err := k8sClient.Delete(ctx, backend)
 			Expect(err).Should(Succeed(), "failed to delete trafficManagerBackend")

--- a/test/common/trafficmanager/validator/profile.go
+++ b/test/common/trafficmanager/validator/profile.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	timeout  = time.Second * 90 // need more time to create azure resources
+	timeout  = time.Second * 120 // need more time to create azure resources
 	interval = time.Millisecond * 250
 	// duration used by consistently
 	duration = time.Second * 30

--- a/test/e2e/traffic_manager_test.go
+++ b/test/e2e/traffic_manager_test.go
@@ -581,7 +581,7 @@ var _ = Describe("Test exporting service via Azure traffic manager", Ordered, fu
 			validator.ValidateTrafficManagerBackendStatusAndIgnoringEndpointNameConsistently(ctx, hubClient, backendName, status)
 
 			By("Validating the Azure traffic manager profile")
-			atmProfile = buildDesiredATMProfile(profile, status.Endpoints)
+			atmProfile = buildDesiredATMProfile(profile, nil)
 			atmProfile.Properties.Endpoints = append(atmProfile.Properties.Endpoints, extraTrafficManagerEndpoint)
 			atmValidator.ValidateProfile(ctx, atmProfileName, atmProfile)
 		})

--- a/test/e2e/traffic_manager_test.go
+++ b/test/e2e/traffic_manager_test.go
@@ -83,26 +83,37 @@ var _ = Describe("Test exporting service via Azure traffic manager", Ordered, fu
 	})
 
 	Context("Test updating trafficManagerProfile", Ordered, func() {
-		BeforeAll(func() {
-			By("Updating Azure traffic manager profile")
-			atmProfile.Properties.DNSConfig.TTL = ptr.To(int64(30))
-			atmProfile.Properties.TrafficViewEnrollmentStatus = ptr.To(armtrafficmanager.TrafficViewEnrollmentStatusEnabled)
-			_, err := atmValidator.ProfileClient.CreateOrUpdate(ctx, atmValidator.ResourceGroup, atmProfileName, atmProfile, nil)
-			Expect(err).Should(Succeed(), "Failed to update the Azure traffic manager profile")
+		var wantTrafficViewEnrollmentStatus *armtrafficmanager.TrafficViewEnrollmentStatus
 
+		BeforeEach(func() {
+			wantTrafficViewEnrollmentStatus = ptr.To(armtrafficmanager.TrafficViewEnrollmentStatusDisabled)
+		})
+
+		AfterEach(func() {
 			By("Updating the trafficManagerProfile spec")
 			profile.Spec.MonitorConfig.ToleratedNumberOfFailures = ptr.To(int64(5))
 			Expect(hubClient.Update(ctx, &profile)).Should(Succeed(), "Failed to update the trafficManagerProfile")
-		})
 
-		It("Validating the trafficManagerProfile status", func() {
 			validator.ValidateIfTrafficManagerProfileIsProgrammed(ctx, hubClient, profileName)
 
 			By("Validating the Azure traffic manager profile")
 			atmProfile = buildDesiredATMProfile(profile, nil)
 			// The Controller does not set the trafficViewEnrollmentStatus.
-			atmProfile.Properties.TrafficViewEnrollmentStatus = ptr.To(armtrafficmanager.TrafficViewEnrollmentStatusEnabled)
+			atmProfile.Properties.TrafficViewEnrollmentStatus = wantTrafficViewEnrollmentStatus
 			atmValidator.ValidateProfile(ctx, atmProfileName, atmProfile)
+		})
+
+		It("Updating Azure traffic manager profile", func() {
+			atmProfile.Properties.DNSConfig.TTL = ptr.To(int64(30))
+			atmProfile.Properties.TrafficViewEnrollmentStatus = ptr.To(armtrafficmanager.TrafficViewEnrollmentStatusEnabled)
+			wantTrafficViewEnrollmentStatus = atmProfile.Properties.TrafficViewEnrollmentStatus
+			_, err := atmValidator.ProfileClient.CreateOrUpdate(ctx, atmValidator.ResourceGroup, atmProfileName, atmProfile, nil)
+			Expect(err).Should(Succeed(), "Failed to update the Azure traffic manager profile")
+		})
+
+		It("Deleting Azure traffic manager profile directly", func() {
+			_, err := atmValidator.ProfileClient.Delete(ctx, atmValidator.ResourceGroup, atmProfileName, nil)
+			Expect(err).Should(Succeed(), "Failed to delete the Azure traffic manager profile")
 		})
 	})
 
@@ -269,21 +280,6 @@ var _ = Describe("Test exporting service via Azure traffic manager", Ordered, fu
 
 			By("Validating the trafficManagerBackend status")
 			status = validator.ValidateTrafficManagerBackendIfAcceptedAndIgnoringEndpointName(ctx, hubClient, backendName, false, nil)
-			validator.ValidateTrafficManagerBackendStatusAndIgnoringEndpointNameConsistently(ctx, hubClient, backendName, status)
-		})
-
-		It("Deleting Azure traffic manager profile before creating trafficManagerBackend", func() {
-			By("Deleting Azure traffic manager profile directly")
-			_, err := atmValidator.ProfileClient.Delete(ctx, atmValidator.ResourceGroup, atmProfileName, nil)
-			Expect(err).Should(Succeed(), "Failed to delete the Azure traffic manager profile")
-
-			By("Creating trafficManagerBackend")
-			backend = wm.TrafficManagerBackend()
-			backendName = types.NamespacedName{Namespace: backend.Namespace, Name: backend.Name}
-			Expect(hubClient.Create(ctx, &backend)).Should(Succeed(), "Failed to create the trafficManagerBackend")
-
-			By("Validating the trafficManagerBackend status")
-			status := validator.ValidateTrafficManagerBackendIfAcceptedAndIgnoringEndpointName(ctx, hubClient, backendName, false, nil)
 			validator.ValidateTrafficManagerBackendStatusAndIgnoringEndpointNameConsistently(ctx, hubClient, backendName, status)
 		})
 	})
@@ -581,8 +577,7 @@ var _ = Describe("Test exporting service via Azure traffic manager", Ordered, fu
 			validator.ValidateTrafficManagerBackendStatusAndIgnoringEndpointNameConsistently(ctx, hubClient, backendName, status)
 
 			By("Validating the Azure traffic manager profile")
-			atmProfile = buildDesiredATMProfile(profile, nil)
-			atmProfile.Properties.Endpoints = append(atmProfile.Properties.Endpoints, extraTrafficManagerEndpoint)
+			atmProfile = buildDesiredATMProfile(profile, status.Endpoints)
 			atmValidator.ValidateProfile(ctx, atmProfileName, atmProfile)
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
- To support disabling the endpoint without deleting the trafficManagerBackend use case
- Fix the e2e test flakiness

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] run `make reviewable` for basic local test
- [ ] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

https://github.com/Azure/fleet-networking/actions/runs/12744560087 are green

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
