### PR TITLE
fix: bump go version to fix CVEs

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -17,7 +17,7 @@ env:
   # `public` indicates images to MCR wil be publicly available, and will be removed in the final MCR images
   REGISTRY_REPO: public/aks/fleet
 
-  GO_VERSION: '1.22.7'
+  GO_VERSION: '1.22.12'
 
 jobs:
   prepare-variables:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.22.7'
+  GO_VERSION: '1.22.12'
 
 jobs:
   detect-noop:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.22.7'
+  GO_VERSION: '1.22.12'
 
 jobs:
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -19,7 +19,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_VERSION: latest
 
-  GO_VERSION: '1.22.7'
+  GO_VERSION: '1.22.12'
 
 jobs:
   export-registry:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,7 +18,7 @@ env:
   MEMBER_NET_CONTROLLER_MANAGER_IMAGE_NAME: member-net-controller-manager
   MCS_CONTROLLER_MANAGER_IMAGE_NAME: mcs-controller-manager
 
-  GO_VERSION: '1.22.7'
+  GO_VERSION: '1.22.12'
 
 jobs:
   export-registry:

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.22.7'
+  GO_VERSION: '1.22.12'
 
 jobs:
   detect-noop:

--- a/docker/hub-net-controller-manager.Dockerfile
+++ b/docker/hub-net-controller-manager.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.7 as builder
+FROM golang:1.22.12 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docker/mcs-controller-manager.Dockerfile
+++ b/docker/mcs-controller-manager.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.7 as builder
+FROM golang:1.22.12 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docker/member-net-controller-manager.Dockerfile
+++ b/docker/member-net-controller-manager.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.7 as builder
+FROM golang:1.22.12 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.goms.io/fleet-networking
 
-go 1.22.7
+go 1.22.12
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0


### PR DESCRIPTION
**What type of PR is this?**


hub-net-controller-manager (gobinary)

Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 3, HIGH: 0, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │        Fixed Version         │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-45336 │ MEDIUM   │ fixed  │ 1.22.7            │ 1.22.11, 1.23.5, 1.24.0-rc.2 │ golang: net/http: net/http: sensitive headers incorrectly    │
│         │                │          │        │                   │                              │ sent after cross-domain redirect                             │
│         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2024-45336                   │
│         ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-45341 │          │        │                   │                              │ golang: crypto/x509: crypto/x509: usage of IPv6 zone IDs can │
│         │                │          │        │                   │                              │ bypass URI name...                                           │
│         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2024-45341                   │
│         ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-22866 │          │        │                   │ 1.22.12, 1.23.6, 1.24.0-rc.3 │ crypto/internal/nistec: golang: Timing sidechannel for P-256 │
│         │                │          │        │                   │                              │ on ppc64le in crypto/internal/nistec                         │
│         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-22866                   │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────┴──────────────────────────────────────────────────────────────┘


**What this PR does / why we need it**:
Fixes the CVEs above.
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] run `make reviewable` for basic local test
- [x] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to be tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
