### PR TITLE
feat: populate the resourceID of profile status

### DIFF
--- a/pkg/controllers/hub/trafficmanagerbackend/suite_test.go
+++ b/pkg/controllers/hub/trafficmanagerbackend/suite_test.go
@@ -298,10 +298,10 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	profileClient, err := fakeprovider.NewProfileClient("default-sub")
+	profileClient, err := fakeprovider.NewProfileClient()
 	Expect(err).Should(Succeed(), "failed to create the fake profile client")
 
-	endpointClient, err := fakeprovider.NewEndpointsClient("default-sub")
+	endpointClient, err := fakeprovider.NewEndpointsClient()
 	Expect(err).Should(Succeed(), "failed to create the fake endpoint client")
 
 	generateAzureTrafficManagerProfileNameFunc = func(profile *fleetnetv1beta1.TrafficManagerProfile) string {

--- a/pkg/controllers/hub/trafficmanagerprofile/controller.go
+++ b/pkg/controllers/hub/trafficmanagerprofile/controller.go
@@ -236,6 +236,7 @@ func (r *Reconciler) updateProfileStatus(ctx context.Context, profile *fleetnetv
 		if atmProfile.ID != nil {
 			profile.Status.ResourceID = *atmProfile.ID
 		} else {
+			profile.Status.ResourceID = "" // reset the resource ID
 			err := controller.NewUnexpectedBehaviorError(fmt.Errorf("got nil ID for Azure Traffic Manager profile"))
 			klog.ErrorS(err, "Unexpected value returned by the Azure Traffic Manager", "trafficManagerProfile", profileKObj, "resourceGroup", profile.Spec.ResourceGroup, "atmProfileName", atmProfile.Name)
 		}

--- a/pkg/controllers/hub/trafficmanagerprofile/controller.go
+++ b/pkg/controllers/hub/trafficmanagerprofile/controller.go
@@ -230,13 +230,19 @@ func (r *Reconciler) updateProfileStatus(ctx context.Context, profile *fleetnetv
 			profile.Status.DNSName = atmProfile.Properties.DNSConfig.Fqdn
 		} else {
 			err := fmt.Errorf("got nil DNSConfig for Azure Traffic Manager profile")
-			klog.ErrorS(controller.NewUnexpectedBehaviorError(err), "Unexpected value returned by the Azure Traffic Manager", "trafficManagerProfile", profileKObj, "atmProfileName", atmProfile.Name)
+			klog.ErrorS(controller.NewUnexpectedBehaviorError(err), "Unexpected value returned by the Azure Traffic Manager", "trafficManagerProfile", profileKObj, "resourceGroup", profile.Spec.ResourceGroup, "atmProfileName", atmProfile.Name)
 			profile.Status.DNSName = nil // reset the DNS name
 		}
+		if atmProfile.ID != nil {
+			profile.Status.ResourceID = *atmProfile.ID
+		} else {
+			err := controller.NewUnexpectedBehaviorError(fmt.Errorf("got nil ID for Azure Traffic Manager profile"))
+			klog.ErrorS(err, "Unexpected value returned by the Azure Traffic Manager", "trafficManagerProfile", profileKObj, "resourceGroup", profile.Spec.ResourceGroup, "atmProfileName", atmProfile.Name)
+		}
 	} else {
-		profile.Status.DNSName = nil // reset the DNS name
+		profile.Status.DNSName = nil   // reset the DNS name
+		profile.Status.ResourceID = "" // reset the resource ID
 	}
-
 	cond := metav1.Condition{
 		Type:               string(fleetnetv1beta1.TrafficManagerProfileConditionProgrammed),
 		Status:             metav1.ConditionTrue,

--- a/pkg/controllers/hub/trafficmanagerprofile/controller_integration_test.go
+++ b/pkg/controllers/hub/trafficmanagerprofile/controller_integration_test.go
@@ -49,6 +49,8 @@ var _ = Describe("Test TrafficManagerProfile Controller", func() {
 	Context("When updating existing valid trafficManagerProfile", Ordered, func() {
 		name := fakeprovider.ValidProfileName
 		var profile *fleetnetv1beta1.TrafficManagerProfile
+		profileResourceID := fmt.Sprintf(fakeprovider.ProfileResourceIDFormat, fakeprovider.DefaultSubscriptionID, fakeprovider.DefaultResourceGroupName, name)
+
 		relativeDNSName := fmt.Sprintf(DNSRelativeNameFormat, testNamespace, name)
 		fqdn := fmt.Sprintf(fakeprovider.ProfileDNSNameFormat, relativeDNSName)
 
@@ -66,7 +68,8 @@ var _ = Describe("Test TrafficManagerProfile Controller", func() {
 				},
 				Spec: profile.Spec,
 				Status: fleetnetv1beta1.TrafficManagerProfileStatus{
-					DNSName: ptr.To(fqdn),
+					DNSName:    ptr.To(fqdn),
+					ResourceID: profileResourceID,
 					Conditions: []metav1.Condition{
 						{
 							Status:             metav1.ConditionTrue,
@@ -122,6 +125,7 @@ var _ = Describe("Test TrafficManagerProfile Controller", func() {
 	Context("When updating existing valid trafficManagerProfile with no changes", Ordered, func() {
 		name := fakeprovider.ValidProfileName
 		var profile *fleetnetv1beta1.TrafficManagerProfile
+		profileResourceID := fmt.Sprintf(fakeprovider.ProfileResourceIDFormat, fakeprovider.DefaultSubscriptionID, fakeprovider.DefaultResourceGroupName, name)
 
 		It("AzureTrafficManager should be configured", func() {
 			By("By creating a new TrafficManagerProfile")
@@ -154,7 +158,8 @@ var _ = Describe("Test TrafficManagerProfile Controller", func() {
 				Spec: profile.Spec,
 				Status: fleetnetv1beta1.TrafficManagerProfileStatus{
 					// The DNS name is returned by the fake Azure GET call.
-					DNSName: ptr.To(fmt.Sprintf(fakeprovider.ProfileDNSNameFormat, name)),
+					DNSName:    ptr.To(fmt.Sprintf(fakeprovider.ProfileDNSNameFormat, name)),
+					ResourceID: profileResourceID,
 					Conditions: []metav1.Condition{
 						{
 							Status:             metav1.ConditionTrue,

--- a/pkg/controllers/hub/trafficmanagerprofile/suite_test.go
+++ b/pkg/controllers/hub/trafficmanagerprofile/suite_test.go
@@ -92,7 +92,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	profileClient, err := fakeprovider.NewProfileClient("default-sub")
+	profileClient, err := fakeprovider.NewProfileClient()
 	Expect(err).Should(Succeed(), "failed to create the fake profile client")
 
 	generateAzureTrafficManagerProfileNameFunc = func(profile *fleetnetv1beta1.TrafficManagerProfile) string {

--- a/test/common/trafficmanager/fakeprovider/endpoint.go
+++ b/test/common/trafficmanager/fakeprovider/endpoint.go
@@ -32,12 +32,12 @@ var (
 )
 
 // NewEndpointsClient creates a client which talks to a fake endpoint server.
-func NewEndpointsClient(subscriptionID string) (*armtrafficmanager.EndpointsClient, error) {
+func NewEndpointsClient() (*armtrafficmanager.EndpointsClient, error) {
 	fakeServer := fake.EndpointsServer{
 		Delete:         EndpointDelete,
 		CreateOrUpdate: EndpointCreateOrUpdate,
 	}
-	clientFactory, err := armtrafficmanager.NewClientFactory(subscriptionID, &azcorefake.TokenCredential{},
+	clientFactory, err := armtrafficmanager.NewClientFactory(DefaultSubscriptionID, &azcorefake.TokenCredential{},
 		&arm.ClientOptions{
 			ClientOptions: azcore.ClientOptions{
 				Transport: fake.NewEndpointsServerTransport(&fakeServer),

--- a/test/common/trafficmanager/validator/profile.go
+++ b/test/common/trafficmanager/validator/profile.go
@@ -63,7 +63,7 @@ func ValidateTrafficManagerProfile(ctx context.Context, k8sClient client.Client,
 }
 
 // ValidateIfTrafficManagerProfileIsProgrammed validates the trafficManagerProfile is programmed and returns the DNSName.
-func ValidateIfTrafficManagerProfileIsProgrammed(ctx context.Context, k8sClient client.Client, profileName types.NamespacedName, isProgrammed bool, timeout time.Duration) *fleetnetv1beta1.TrafficManagerProfile {
+func ValidateIfTrafficManagerProfileIsProgrammed(ctx context.Context, k8sClient client.Client, profileName types.NamespacedName, isProgrammed bool, wantResourceID string, timeout time.Duration) *fleetnetv1beta1.TrafficManagerProfile {
 	wantDNSName := fmt.Sprintf("%s-%s.trafficmanager.net", profileName.Namespace, profileName.Name)
 	var profile fleetnetv1beta1.TrafficManagerProfile
 	gomega.Eventually(func() error {
@@ -82,6 +82,7 @@ func ValidateIfTrafficManagerProfileIsProgrammed(ctx context.Context, k8sClient 
 						ObservedGeneration: profile.Generation,
 					},
 				},
+				ResourceID: wantResourceID,
 			}
 		} else {
 			wantStatus = fleetnetv1beta1.TrafficManagerProfileStatus{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -34,7 +34,8 @@ const (
 	azureSubscriptionEnv                = "AZURE_SUBSCRIPTION_ID"
 	azureTrafficManagerResourceGroupEnv = "AZURE_RESOURCE_GROUP"
 
-	azureDNSFormat = "%s.%s.cloudapp.azure.com"
+	azureDNSFormat                             = "%s.%s.cloudapp.azure.com"
+	azureTrafficManagerProfileResourceIDFormat = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/trafficManagerProfiles/%s"
 )
 
 var (
@@ -54,6 +55,7 @@ var (
 	atmValidator *azureprovider.Validator
 	pipClient    publicipaddressclient.Interface
 
+	subscriptionID   string
 	atmResourceGroup string
 )
 
@@ -92,7 +94,7 @@ var _ = BeforeSuite(func() {
 })
 
 func initAzureClients() {
-	subscriptionID := os.Getenv(azureSubscriptionEnv)
+	subscriptionID = os.Getenv(azureSubscriptionEnv)
 	Expect(subscriptionID).ShouldNot(BeEmpty(), "Azure subscription ID is not set")
 
 	atmResourceGroup = os.Getenv(azureTrafficManagerResourceGroupEnv)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
support resourceID in the profile status

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #237

**Requirements**:

- [ ] run `make reviewable` for basic local test
- [ ] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to be tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
