### PR TITLE
fix: retry when getting 4xx error

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -100,6 +100,8 @@ jobs:
           AZURE_NETWORK_SETTING: ${{ matrix.network-setting }}
           AZURE_RESOURCE_GROUP: ${{ env.AZURE_RESOURCE_GROUP }}
           ENABLE_TRAFFIC_MANAGER: ${{ matrix.enable-traffic-manager }}
+      - name: Wait for role assignments to be effective
+        run: sleep 3m
       - name: Run e2e tests
         run: |
           make e2e-tests

--- a/pkg/controllers/hub/trafficmanagerbackend/controller_integration_test.go
+++ b/pkg/controllers/hub/trafficmanagerbackend/controller_integration_test.go
@@ -753,7 +753,7 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 			validator.ValidateTrafficManagerBackendConsistently(ctx, k8sClient, &want)
 		})
 
-		It("Updating the ServiceImport status", func() {
+		It("Simulating a 403 error response from the provider server and updating the ServiceImport status", func() {
 			// The test is running in sequence, so it's safe to set this value.
 			fakeprovider.EnableEndpointForbiddenErr()
 			serviceImport.Status = fleetnetv1alpha1.ServiceImportStatus{
@@ -766,7 +766,7 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 			Expect(k8sClient.Status().Update(ctx, serviceImport)).Should(Succeed(), "failed to create serviceImport")
 		})
 
-		It("Validating trafficManagerBackend", func() {
+		It("Should set trafficManagerBackend as accepted false", func() {
 			want := fleetnetv1beta1.TrafficManagerBackend{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       backendName,
@@ -782,7 +782,7 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 			validator.ValidateTrafficManagerBackendConsistently(ctx, k8sClient, &want)
 		})
 
-		It("Setting the fake provider server to stop returning 403 error", func() {
+		It("Should reconcile the endpoint back after the provider server stops returning 403", func() {
 			fakeprovider.DisableEndpointForbiddenErr()
 			want := fleetnetv1beta1.TrafficManagerBackend{
 				ObjectMeta: metav1.ObjectMeta{
@@ -810,7 +810,6 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 			}
 			validator.ValidateTrafficManagerBackend(ctx, k8sClient, &want)
 			validator.ValidateTrafficManagerBackendConsistently(ctx, k8sClient, &want)
-			fakeprovider.EnableEndpointForbiddenErr()
 		})
 
 		It("Updating the ServiceImport status", func() {

--- a/pkg/controllers/hub/trafficmanagerbackend/suite_test.go
+++ b/pkg/controllers/hub/trafficmanagerbackend/suite_test.go
@@ -44,7 +44,8 @@ var (
 	originalGenerateAzureTrafficManagerProfileNameFunc        = generateAzureTrafficManagerProfileNameFunc
 	originalGenerateAzureTrafficManagerEndpointNamePrefixFunc = generateAzureTrafficManagerEndpointNamePrefixFunc
 
-	memberClusterNames     = []string{fakeprovider.ClusterName, "member-2", "member-3", "member-4", fakeprovider.CreateBadRequestErrEndpointClusterName, fakeprovider.CreateInternalServerErrEndpointClusterName}
+	memberClusterNames = []string{fakeprovider.ClusterName, "member-2", "member-3", "member-4",
+		fakeprovider.CreateBadRequestErrEndpointClusterName, fakeprovider.CreateInternalServerErrEndpointClusterName, fakeprovider.CreateForbiddenErrEndpointClusterName}
 	internalServiceExports = []fleetnetv1alpha1.InternalServiceExport{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -199,6 +200,34 @@ var (
 				},
 				ServiceReference: fleetnetv1alpha1.ExportedObjectReference{
 					ClusterID:       memberClusterNames[5],
+					Kind:            "Service",
+					Namespace:       testNamespace,
+					Name:            serviceName,
+					ResourceVersion: "0",
+					Generation:      0,
+					UID:             "0",
+					NamespacedName:  fmt.Sprintf("%s/%s", testNamespace, serviceName),
+				},
+				Type:                 corev1.ServiceTypeLoadBalancer,
+				IsDNSLabelConfigured: true,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "endpoint-create-forbidden-err",
+				Namespace: memberClusterNames[6],
+			},
+			Spec: fleetnetv1alpha1.InternalServiceExportSpec{
+				Ports: []fleetnetv1alpha1.ServicePort{
+					{
+						Name:       "portA",
+						Protocol:   "TCP",
+						Port:       8080,
+						TargetPort: intstr.IntOrString{IntVal: 8080},
+					},
+				},
+				ServiceReference: fleetnetv1alpha1.ExportedObjectReference{
+					ClusterID:       memberClusterNames[6],
 					Kind:            "Service",
 					Namespace:       testNamespace,
 					Name:            serviceName,

--- a/pkg/controllers/hub/trafficmanagerprofile/controller.go
+++ b/pkg/controllers/hub/trafficmanagerprofile/controller.go
@@ -275,7 +275,7 @@ func (r *Reconciler) updateProfileStatus(ctx context.Context, profile *fleetnetv
 		return ctrl.Result{}, controller.NewUpdateIgnoreConflictError(err)
 	}
 	klog.V(2).InfoS("Updated the trafficProfile status", "trafficManagerProfile", profileKObj, "status", profile.Status)
-	return ctrl.Result{}, armErr
+	return ctrl.Result{}, armErr // return the error to retry the reconciliation
 }
 
 func generateAzureTrafficManagerProfile(profile *fleetnetv1beta1.TrafficManagerProfile) armtrafficmanager.Profile {

--- a/test/common/trafficmanager/fakeprovider/profile.go
+++ b/test/common/trafficmanager/fakeprovider/profile.go
@@ -40,6 +40,7 @@ const (
 	ClusterName                                = "member-1"
 	CreateBadRequestErrEndpointClusterName     = "create-bad-request-endpoint-cluster"
 	CreateInternalServerErrEndpointClusterName = "create-internal-err-endpoint-cluster"
+	CreateForbiddenErrEndpointClusterName      = "create-forbidden-endpoint-cluster"
 
 	ProfileDNSNameFormat                  = "%s.trafficmanager.net"
 	azureTrafficManagerEndpointTypePrefix = "Microsoft.Network/trafficManagerProfiles/"
@@ -53,6 +54,7 @@ var (
 	FailToDeleteEndpointName            = fmt.Sprintf("%s#%s#%s", ValidBackendName, ServiceImportName, "fail-to-delete")
 	CreateBadRequestErrEndpointName     = fmt.Sprintf("%s#%s#%s", ValidBackendName, ServiceImportName, CreateBadRequestErrEndpointClusterName)
 	CreateInternalServerErrEndpointName = fmt.Sprintf("%s#%s#%s", ValidBackendName, ServiceImportName, CreateInternalServerErrEndpointClusterName)
+	CreateForbiddenErrEndpointName      = fmt.Sprintf("%s#%s#%s", ValidBackendName, ServiceImportName, CreateForbiddenErrEndpointClusterName)
 )
 
 // NewProfileClient creates a client which talks to a fake profile server.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
- retry when the agent loses the permission in the middle
- wait few mins before starting the e2e tests so that the permission assignment takes effect. https://github.com/Azure/fleet-networking/actions/runs/13297039395/job/37147419480

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] run `make reviewable` for basic local test
- [ ] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested
added integration tests
e2e tests are green https://github.com/Azure/fleet-networking/actions/runs/13365274390

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
