### PR TITLE
refactor: expose the export annotation util

### DIFF
--- a/pkg/common/objectmeta/objectmeta_test.go
+++ b/pkg/common/objectmeta/objectmeta_test.go
@@ -5,11 +5,112 @@ Licensed under the MIT license.
 
 package objectmeta
 
-import "testing"
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fleetnetv1alpha1 "go.goms.io/fleet-networking/api/v1alpha1"
+)
 
 func TestAzureTrafficManagerProfileTagKey(t *testing.T) {
 	want := "networking.fleet.azure.com.trafficManagerProfile"
 	if got := AzureTrafficManagerProfileTagKey; got != want {
 		t.Errorf("AzureTrafficManagerProfileTagKey = %v, want %v", got, want)
+	}
+}
+
+func TestExtractWeightFromServiceExport(t *testing.T) {
+	testCases := []struct {
+		name       string
+		svcExport  *fleetnetv1alpha1.ServiceExport
+		wantWeight int64
+		wantError  bool
+	}{
+		{
+			name: "default weight when annotation is missing",
+			svcExport: &fleetnetv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			wantWeight: 1,
+		},
+		{
+			name: "valid weight annotation",
+			svcExport: &fleetnetv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceExportAnnotationWeight: "500",
+					},
+				},
+			},
+			wantWeight: 500,
+		},
+		{
+			name: "test 0 is valid weight annotation",
+			svcExport: &fleetnetv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceExportAnnotationWeight: "0",
+					},
+				},
+			},
+			wantWeight: 0,
+		},
+		{
+			name: "test 1000 is valid weight annotation",
+			svcExport: &fleetnetv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceExportAnnotationWeight: "1000",
+					},
+				},
+			},
+			wantWeight: 1000,
+		},
+		{
+			name: "invalid weight annotation (non-integer)",
+			svcExport: &fleetnetv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceExportAnnotationWeight: "invalid",
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid weight annotation (out of range)",
+			svcExport: &fleetnetv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceExportAnnotationWeight: "2000",
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid weight annotation (out of range)",
+			svcExport: &fleetnetv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceExportAnnotationWeight: "-2",
+					},
+				},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotWeight, err := ExtractWeightFromServiceExport(tc.svcExport)
+			if (err != nil) != tc.wantError {
+				t.Fatalf("ExtractWeightFromServiceExport() error = %v, want %v", err, tc.wantError)
+			}
+			if !tc.wantError && gotWeight != tc.wantWeight {
+				t.Errorf("ExtractWeightFromServiceExport() weight = %d, want %d", gotWeight, tc.wantWeight)
+			}
+		})
 	}
 }

--- a/pkg/controllers/member/serviceexport/controller_integration_test.go
+++ b/pkg/controllers/member/serviceexport/controller_integration_test.go
@@ -23,8 +23,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"go.goms.io/fleet/pkg/utils/controller"
-
 	fleetnetv1alpha1 "go.goms.io/fleet-networking/api/v1alpha1"
 	"go.goms.io/fleet-networking/pkg/common/metrics"
 	"go.goms.io/fleet-networking/pkg/common/objectmeta"
@@ -426,7 +424,7 @@ var _ = Describe("serviceexport controller", func() {
 
 		It("should mark the service export as valid + should export the service", func() {
 			By("make sure the serviceExport is marked as invalid")
-			err := controller.NewUserError(fmt.Errorf("the weight annotation is not in the range [0, 1000]: %s", svcExport.Annotations[objectmeta.ServiceExportAnnotationWeight]))
+			err := fmt.Errorf("the weight annotation is not in the range [0, 1000]: %s", svcExport.Annotations[objectmeta.ServiceExportAnnotationWeight])
 			expectedCond := metav1.Condition{
 				Type:               string(fleetnetv1alpha1.ServiceExportValid),
 				Status:             metav1.ConditionFalse,
@@ -597,7 +595,7 @@ var _ = Describe("serviceexport controller", func() {
 			Expect(memberClient.Update(ctx, svcExport)).Should(Succeed())
 
 			By("make sure the serviceExport is marked as invalid")
-			err := controller.NewUserError(fmt.Errorf("the weight annotation is not in the range [0, 1000]: %s", svcExport.Annotations[objectmeta.ServiceExportAnnotationWeight]))
+			err := fmt.Errorf("the weight annotation is not in the range [0, 1000]: %s", svcExport.Annotations[objectmeta.ServiceExportAnnotationWeight])
 			expectedCond := metav1.Condition{
 				Type:               string(fleetnetv1alpha1.ServiceExportValid),
 				Status:             metav1.ConditionFalse,

--- a/pkg/controllers/member/serviceexport/controller_test.go
+++ b/pkg/controllers/member/serviceexport/controller_test.go
@@ -28,8 +28,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"go.goms.io/fleet/pkg/utils/controller"
-
 	fleetnetv1alpha1 "go.goms.io/fleet-networking/api/v1alpha1"
 	"go.goms.io/fleet-networking/pkg/common/metrics"
 	"go.goms.io/fleet-networking/pkg/common/objectmeta"
@@ -1523,106 +1521,6 @@ func TestSetAzureRelatedInformation(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("setAzureRelatedInformation() internalServiceExport mismatch (-want, +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestExtractWeightFromServiceExport(t *testing.T) {
-	testCases := []struct {
-		name        string
-		svcExport   *fleetnetv1alpha1.ServiceExport
-		wantWeight  int64
-		expectError bool
-	}{
-		{
-			name: "default weight when annotation is missing",
-			svcExport: &fleetnetv1alpha1.ServiceExport{
-				ObjectMeta: metav1.ObjectMeta{},
-			},
-			wantWeight: 1,
-		},
-		{
-			name: "valid weight annotation",
-			svcExport: &fleetnetv1alpha1.ServiceExport{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						objectmeta.ServiceExportAnnotationWeight: "500",
-					},
-				},
-			},
-			wantWeight: 500,
-		},
-		{
-			name: "test 0 is valid weight annotation",
-			svcExport: &fleetnetv1alpha1.ServiceExport{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						objectmeta.ServiceExportAnnotationWeight: "0",
-					},
-				},
-			},
-			wantWeight: 0,
-		},
-		{
-			name: "test 1000 is valid weight annotation",
-			svcExport: &fleetnetv1alpha1.ServiceExport{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						objectmeta.ServiceExportAnnotationWeight: "1000",
-					},
-				},
-			},
-			wantWeight: 1000,
-		},
-		{
-			name: "invalid weight annotation (non-integer)",
-			svcExport: &fleetnetv1alpha1.ServiceExport{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						objectmeta.ServiceExportAnnotationWeight: "invalid",
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "invalid weight annotation (out of range)",
-			svcExport: &fleetnetv1alpha1.ServiceExport{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						objectmeta.ServiceExportAnnotationWeight: "2000",
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "invalid weight annotation (out of range)",
-			svcExport: &fleetnetv1alpha1.ServiceExport{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						objectmeta.ServiceExportAnnotationWeight: "-2",
-					},
-				},
-			},
-			expectError: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			gotWeight, err := extractWeightFromServiceExport(tc.svcExport)
-			if (err != nil) != tc.expectError {
-				t.Fatalf("extractWeightFromServiceExport() error = %v, expectError %v", err, tc.expectError)
-			}
-			// make sure the returned error is categorized as user error
-			if tc.expectError {
-				if !errors.Is(err, controller.ErrUserError) {
-					t.Fatalf("extractWeightFromServiceExport() error = %v, expect user error", err)
-				}
-			} else if gotWeight != tc.wantWeight {
-				t.Fatalf("extractWeightFromServiceExport() gotWeight = %d, want %d", gotWeight, tc.wantWeight)
 			}
 		})
 	}

--- a/pkg/controllers/member/serviceexport/suite_test.go
+++ b/pkg/controllers/member/serviceexport/suite_test.go
@@ -57,7 +57,7 @@ func setUpResources() {
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecs(t, "InternalServiceExport Controller Suite")
+	RunSpecs(t, "ServiceExport Controller Suite")
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Expose this util so that fleet repo can use it to validate the weight annotation.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] run `make reviewable` for basic local test
- [ ] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

[e2e test](https://github.com/Azure/fleet-networking/actions/runs/13715075354)

### Special notes for your reviewer

ExtractWeightFromServiceExport does not return the User error anymore, and it will depend on the caller to wrap it. So that it can avoid the loop dep.
