### PR TITLE
fix: fix the service export condition

### DIFF
--- a/pkg/common/condition/condition.go
+++ b/pkg/common/condition/condition.go
@@ -73,9 +73,13 @@ func UnconflictedServiceExportConflictCondition(internalServiceExport fleetnetv1
 		Name:      internalServiceExport.Spec.ServiceReference.Name,
 	}
 	return metav1.Condition{
-		Type:               string(fleetnetv1alpha1.ServiceExportConflict),
-		Status:             metav1.ConditionFalse,
-		Reason:             conditionReasonNoConflictFound,
+		Type:   string(fleetnetv1alpha1.ServiceExportConflict),
+		Status: metav1.ConditionFalse,
+		Reason: conditionReasonNoConflictFound,
+		// Right now, it becomes very tricky because we need to consider both serviceExport generation & service generation.
+		// The service can be updated without updating the serviceExport.
+		// However, service controller does not populate the generation on the spec.
+		// use the internalServiceExport generation? any service & weight annotation changes will update the internalServiceExport generation.
 		ObservedGeneration: internalServiceExport.Spec.ServiceReference.Generation, // use the generation of the original object
 		Message:            fmt.Sprintf("service %s is exported without conflict", svcName),
 	}

--- a/pkg/common/condition/condition.go
+++ b/pkg/common/condition/condition.go
@@ -73,14 +73,10 @@ func UnconflictedServiceExportConflictCondition(internalServiceExport fleetnetv1
 		Name:      internalServiceExport.Spec.ServiceReference.Name,
 	}
 	return metav1.Condition{
-		Type:   string(fleetnetv1alpha1.ServiceExportConflict),
-		Status: metav1.ConditionFalse,
-		Reason: conditionReasonNoConflictFound,
-		// Right now, it becomes very tricky because we need to consider both serviceExport generation & service generation.
-		// The service can be updated without updating the serviceExport.
-		// However, service controller does not populate the generation on the spec.
-		// use the internalServiceExport generation? any service & weight annotation changes will update the internalServiceExport generation.
-		ObservedGeneration: internalServiceExport.Spec.ServiceReference.Generation, // use the generation of the original object
+		Type:               string(fleetnetv1alpha1.ServiceExportConflict),
+		Status:             metav1.ConditionFalse,
+		Reason:             conditionReasonNoConflictFound,
+		ObservedGeneration: internalServiceExport.Generation,
 		Message:            fmt.Sprintf("service %s is exported without conflict", svcName),
 	}
 }
@@ -95,7 +91,7 @@ func ConflictedServiceExportConflictCondition(internalServiceExport fleetnetv1al
 		Type:               string(fleetnetv1alpha1.ServiceExportConflict),
 		Status:             metav1.ConditionTrue,
 		Reason:             conditionReasonConflictFound,
-		ObservedGeneration: internalServiceExport.Spec.ServiceReference.Generation, // use the generation of the original object
+		ObservedGeneration: internalServiceExport.Generation,
 		Message:            fmt.Sprintf("service %s is in conflict with other exported services", svcName),
 	}
 }

--- a/pkg/common/condition/condition_test.go
+++ b/pkg/common/condition/condition_test.go
@@ -282,7 +282,7 @@ func TestUnconflictedServiceExportConflictCondition(t *testing.T) {
 func TestConflictedServiceExportConflictCondition(t *testing.T) {
 	input := fleetnetv1alpha1.InternalServiceExport{
 		ObjectMeta: metav1.ObjectMeta{
-			Generation: 456,
+			Generation: 123,
 		},
 		Spec: fleetnetv1alpha1.InternalServiceExportSpec{
 			Ports: []fleetnetv1alpha1.ServicePort{
@@ -306,7 +306,7 @@ func TestConflictedServiceExportConflictCondition(t *testing.T) {
 				Namespace:       "test-ns",
 				Name:            "test-svc",
 				ResourceVersion: "0",
-				Generation:      123,
+				Generation:      456,
 				UID:             "0",
 			},
 		},
@@ -315,7 +315,7 @@ func TestConflictedServiceExportConflictCondition(t *testing.T) {
 		Type:               string(fleetnetv1alpha1.ServiceExportConflict),
 		Status:             metav1.ConditionTrue,
 		Reason:             conditionReasonConflictFound,
-		ObservedGeneration: 456,
+		ObservedGeneration: 123,
 		Message:            "service test-ns/test-svc is in conflict with other exported services",
 	}
 	got := ConflictedServiceExportConflictCondition(input)

--- a/pkg/common/condition/condition_test.go
+++ b/pkg/common/condition/condition_test.go
@@ -236,6 +236,9 @@ func TestEqualConditionIgnoreReason(t *testing.T) {
 
 func TestUnconflictedServiceExportConflictCondition(t *testing.T) {
 	input := fleetnetv1alpha1.InternalServiceExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Generation: 456,
+		},
 		Spec: fleetnetv1alpha1.InternalServiceExportSpec{
 			Ports: []fleetnetv1alpha1.ServicePort{
 				{
@@ -267,7 +270,7 @@ func TestUnconflictedServiceExportConflictCondition(t *testing.T) {
 		Type:               string(fleetnetv1alpha1.ServiceExportConflict),
 		Status:             metav1.ConditionFalse,
 		Reason:             conditionReasonNoConflictFound,
-		ObservedGeneration: 123, // use the generation of the original object
+		ObservedGeneration: 456,
 		Message:            "service test-ns/test-svc is exported without conflict",
 	}
 	got := UnconflictedServiceExportConflictCondition(input)
@@ -278,6 +281,9 @@ func TestUnconflictedServiceExportConflictCondition(t *testing.T) {
 
 func TestConflictedServiceExportConflictCondition(t *testing.T) {
 	input := fleetnetv1alpha1.InternalServiceExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Generation: 456,
+		},
 		Spec: fleetnetv1alpha1.InternalServiceExportSpec{
 			Ports: []fleetnetv1alpha1.ServicePort{
 				{
@@ -309,7 +315,7 @@ func TestConflictedServiceExportConflictCondition(t *testing.T) {
 		Type:               string(fleetnetv1alpha1.ServiceExportConflict),
 		Status:             metav1.ConditionTrue,
 		Reason:             conditionReasonConflictFound,
-		ObservedGeneration: 123,
+		ObservedGeneration: 456,
 		Message:            "service test-ns/test-svc is in conflict with other exported services",
 	}
 	got := ConflictedServiceExportConflictCondition(input)

--- a/pkg/controllers/hub/internalserviceexport/controller_integration_test.go
+++ b/pkg/controllers/hub/internalserviceexport/controller_integration_test.go
@@ -153,14 +153,14 @@ var _ = Describe("Test InternalServiceExport Controller", func() {
 
 			By("Checking internalServiceExportA status")
 			Eventually(func() string {
-				want := fleetnetv1alpha1.InternalServiceExportStatus{
-					Conditions: []metav1.Condition{
-						unconflictedServiceExportConflictCondition(testNamespace, testServiceName),
-					},
-				}
 				key := types.NamespacedName{Namespace: testMemberClusterA, Name: testName}
 				if err := k8sClient.Get(ctx, key, internalServiceExportA); err != nil {
 					return err.Error()
+				}
+				want := fleetnetv1alpha1.InternalServiceExportStatus{
+					Conditions: []metav1.Condition{
+						unconflictedServiceExportConflictCondition(testNamespace, testServiceName, internalServiceExportA.Generation),
+					},
 				}
 				return cmp.Diff(want, internalServiceExportA.Status, options...)
 			}, timeout, interval).Should(BeEmpty())
@@ -170,14 +170,14 @@ var _ = Describe("Test InternalServiceExport Controller", func() {
 
 			By("Checking internalServiceExportB status")
 			Eventually(func() string {
-				want := fleetnetv1alpha1.InternalServiceExportStatus{
-					Conditions: []metav1.Condition{
-						unconflictedServiceExportConflictCondition(testNamespace, testServiceName),
-					},
-				}
 				key := types.NamespacedName{Namespace: testMemberClusterB, Name: testName}
 				if err := k8sClient.Get(ctx, key, internalServiceExportB); err != nil {
 					return err.Error()
+				}
+				want := fleetnetv1alpha1.InternalServiceExportStatus{
+					Conditions: []metav1.Condition{
+						unconflictedServiceExportConflictCondition(testNamespace, testServiceName, internalServiceExportB.Generation),
+					},
 				}
 				return cmp.Diff(want, internalServiceExportB.Status, options...)
 			}, timeout, interval).Should(BeEmpty())
@@ -313,14 +313,14 @@ var _ = Describe("Test InternalServiceExport Controller", func() {
 
 			By("Checking internalServiceExportA status")
 			Eventually(func() string {
-				want := fleetnetv1alpha1.InternalServiceExportStatus{
-					Conditions: []metav1.Condition{
-						unconflictedServiceExportConflictCondition(testNamespace, testServiceName),
-					},
-				}
 				key := types.NamespacedName{Namespace: testMemberClusterA, Name: testName}
 				if err := k8sClient.Get(ctx, key, internalServiceExportA); err != nil {
 					return err.Error()
+				}
+				want := fleetnetv1alpha1.InternalServiceExportStatus{
+					Conditions: []metav1.Condition{
+						unconflictedServiceExportConflictCondition(testNamespace, testServiceName, internalServiceExportA.Generation),
+					},
 				}
 				return cmp.Diff(want, internalServiceExportA.Status, options...)
 			}, timeout, interval).Should(BeEmpty())
@@ -386,14 +386,14 @@ var _ = Describe("Test InternalServiceExport Controller", func() {
 
 			By("Checking internalServiceExportA status")
 			Eventually(func() string {
-				want := fleetnetv1alpha1.InternalServiceExportStatus{
-					Conditions: []metav1.Condition{
-						conflictedServiceExportConflictCondition(testNamespace, testServiceName),
-					},
-				}
 				key := types.NamespacedName{Namespace: testMemberClusterA, Name: testName}
 				if err := k8sClient.Get(ctx, key, internalServiceExportA); err != nil {
 					return err.Error()
+				}
+				want := fleetnetv1alpha1.InternalServiceExportStatus{
+					Conditions: []metav1.Condition{
+						conflictedServiceExportConflictCondition(testNamespace, testServiceName, internalServiceExportA.Generation),
+					},
 				}
 				return cmp.Diff(want, internalServiceExportA.Status, options...)
 			}, timeout, interval).Should(BeEmpty())

--- a/pkg/controllers/member/internalserviceexport/controller.go
+++ b/pkg/controllers/member/internalserviceexport/controller.go
@@ -11,8 +11,6 @@ import (
 	"context"
 	"time"
 
-	"go.goms.io/fleet-networking/pkg/common/condition"
-
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -26,6 +24,7 @@ import (
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	fleetnetv1alpha1 "go.goms.io/fleet-networking/api/v1alpha1"
+	"go.goms.io/fleet-networking/pkg/common/condition"
 	"go.goms.io/fleet-networking/pkg/common/metrics"
 )
 

--- a/pkg/controllers/member/internalserviceexport/controller.go
+++ b/pkg/controllers/member/internalserviceexport/controller.go
@@ -179,7 +179,7 @@ func (r *Reconciler) reportBackConflictCondition(ctx context.Context,
 		klog.V(4).InfoS("No conflict condition to report back", "internalServiceExport", internalSvcExportRef)
 		return false, nil
 	}
-
+	internalSvcExportConflictCond.ObservedGeneration = svcExport.Generation // use the generation of the original object
 	svcExportConflictCond := meta.FindStatusCondition(svcExport.Status.Conditions, string(fleetnetv1alpha1.ServiceExportConflict))
 	if reflect.DeepEqual(internalSvcExportConflictCond, svcExportConflictCond) {
 		// The conflict condition has not changed and there is no need to report back; this is also an expected

--- a/pkg/controllers/member/internalserviceexport/controller.go
+++ b/pkg/controllers/member/internalserviceexport/controller.go
@@ -9,6 +9,7 @@ package internalserviceexport
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,7 +25,6 @@ import (
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	fleetnetv1alpha1 "go.goms.io/fleet-networking/api/v1alpha1"
-	"go.goms.io/fleet-networking/pkg/common/condition"
 	"go.goms.io/fleet-networking/pkg/common/metrics"
 )
 
@@ -184,7 +184,7 @@ func (r *Reconciler) reportBackConflictCondition(ctx context.Context,
 	desiredSvcExportConflictCond := internalSvcExportConflictCond.DeepCopy()
 	desiredSvcExportConflictCond.ObservedGeneration = svcExport.Generation
 	svcExportConflictCond := meta.FindStatusCondition(svcExport.Status.Conditions, string(fleetnetv1alpha1.ServiceExportConflict))
-	if condition.EqualCondition(svcExportConflictCond, desiredSvcExportConflictCond) {
+	if reflect.DeepEqual(internalSvcExportConflictCond, svcExportConflictCond) {
 		// The conflict condition has not changed and there is no need to report back; this is also an expected
 		// behavior.
 		klog.V(4).InfoS("No update on the conflict condition", "internalServiceExport", internalSvcExportRef)

--- a/pkg/controllers/member/internalserviceexport/controller_integration_test.go
+++ b/pkg/controllers/member/internalserviceexport/controller_integration_test.go
@@ -189,7 +189,7 @@ var _ = Describe("internalsvcexport controller", func() {
 		It("should report back conflict condition (no conflict found)", func() {
 			// Add a no conflict condition.
 			meta.SetStatusCondition(&internalSvcExport.Status.Conditions,
-				unconflictedServiceExportConflictCondition(memberUserNS, svcName))
+				unconflictedServiceExportConflictCondition(memberUserNS, svcName, internalSvcExport.Generation))
 			Expect(hubClient.Status().Update(ctx, internalSvcExport)).Should(Succeed())
 
 			Eventually(func() error {
@@ -197,7 +197,7 @@ var _ = Describe("internalsvcexport controller", func() {
 					return fmt.Errorf("serviceExport Get(%+v), got %w, want no error", svcExportKey, err)
 				}
 
-				expectedConds := []metav1.Condition{unconflictedServiceExportConflictCondition(memberUserNS, svcName)}
+				expectedConds := []metav1.Condition{unconflictedServiceExportConflictCondition(memberUserNS, svcName, svcExport.Generation)}
 				if diff := cmp.Diff(svcExport.Status.Conditions, expectedConds, ignoredCondFields); diff != "" {
 					return fmt.Errorf("serviceExport conditions (-got, +want): %s", diff)
 				}
@@ -233,7 +233,7 @@ var _ = Describe("internalsvcexport controller", func() {
 		It("should report back conflict condition (conflict found)", func() {
 			// Add a no conflict condition
 			meta.SetStatusCondition(&internalSvcExport.Status.Conditions,
-				conflictedServiceExportConflictCondition(memberUserNS, svcName))
+				conflictedServiceExportConflictCondition(memberUserNS, svcName, internalSvcExport.Generation))
 			Expect(hubClient.Status().Update(ctx, internalSvcExport)).Should(Succeed())
 
 			Eventually(func() error {
@@ -241,7 +241,7 @@ var _ = Describe("internalsvcexport controller", func() {
 					return fmt.Errorf("serviceExport Get(%+v), got %w, want no error", svcExportKey, err)
 				}
 
-				expectedConds := []metav1.Condition{conflictedServiceExportConflictCondition(memberUserNS, svcName)}
+				expectedConds := []metav1.Condition{conflictedServiceExportConflictCondition(memberUserNS, svcName, svcExport.Generation)}
 				if diff := cmp.Diff(svcExport.Status.Conditions, expectedConds, ignoredCondFields); diff != "" {
 					return fmt.Errorf("serviceExport conditions (-got, +want): %s", diff)
 				}
@@ -286,7 +286,7 @@ var _ = Describe("internalsvcexport controller", func() {
 			// Add a conflict condition
 			Expect(hubClient.Get(ctx, internalSvcExportKey, internalSvcExport)).Should(Succeed())
 			meta.SetStatusCondition(&internalSvcExport.Status.Conditions,
-				conflictedServiceExportConflictCondition(memberUserNS, svcName))
+				conflictedServiceExportConflictCondition(memberUserNS, svcName, internalSvcExport.Generation))
 			Expect(hubClient.Status().Update(ctx, internalSvcExport)).Should(Succeed())
 
 			Consistently(func() error {

--- a/pkg/controllers/member/serviceexport/controller.go
+++ b/pkg/controllers/member/serviceexport/controller.go
@@ -164,7 +164,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 		// Mark the ServiceExport as invalid.
 		klog.V(2).InfoS("Mark service export as invalid (service ineligible)", "service", svcRef)
-		err = r.markServiceExportAsInvalidSvcIneligible(ctx, &svcExport, &svc)
+		err = r.markServiceExportAsInvalidSvcIneligible(ctx, &svcExport)
 		if err != nil {
 			klog.ErrorS(err, "Failed to mark service export as invalid (service ineligible)", "service", svcRef)
 		}
@@ -234,7 +234,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// Mark the ServiceExport as valid.
 	klog.V(2).InfoS("Mark service export as valid", "service", svcRef)
-	if err = r.markServiceExportAsValid(ctx, &svcExport, &svc); err != nil {
+	if err = r.markServiceExportAsValid(ctx, &svcExport); err != nil {
 		klog.ErrorS(err, "Failed to mark service export as valid", "service", svcRef)
 		return ctrl.Result{}, err
 	}
@@ -478,11 +478,11 @@ func (r *Reconciler) removeServiceExportCleanupFinalizer(ctx context.Context, sv
 func (r *Reconciler) markServiceExportAsInvalidNotFound(ctx context.Context, svcExport *fleetnetv1alpha1.ServiceExport) error {
 	validCond := meta.FindStatusCondition(svcExport.Status.Conditions, string(fleetnetv1alpha1.ServiceExportValid))
 	expectedValidCond := &metav1.Condition{
-		Type:   string(fleetnetv1alpha1.ServiceExportValid),
-		Status: metav1.ConditionFalse,
-		// The Service is not found, therefore the observedGeneration field is ignored.
-		Reason:  svcExportInvalidNotFoundCondReason,
-		Message: fmt.Sprintf("service %s/%s is not found", svcExport.Namespace, svcExport.Name),
+		Type:               string(fleetnetv1alpha1.ServiceExportValid),
+		Status:             metav1.ConditionFalse,
+		Reason:             svcExportInvalidNotFoundCondReason,
+		ObservedGeneration: svcExport.Generation,
+		Message:            fmt.Sprintf("service %s/%s is not found", svcExport.Namespace, svcExport.Name),
 	}
 	if condition.EqualCondition(validCond, expectedValidCond) {
 		// A stable state has been reached; no further action is needed.
@@ -494,13 +494,13 @@ func (r *Reconciler) markServiceExportAsInvalidNotFound(ctx context.Context, svc
 }
 
 // markServiceExportAsInvalidSvcIneligible marks a ServiceExport as invalid.
-func (r *Reconciler) markServiceExportAsInvalidSvcIneligible(ctx context.Context, svcExport *fleetnetv1alpha1.ServiceExport, svc *corev1.Service) error {
+func (r *Reconciler) markServiceExportAsInvalidSvcIneligible(ctx context.Context, svcExport *fleetnetv1alpha1.ServiceExport) error {
 	validCond := meta.FindStatusCondition(svcExport.Status.Conditions, string(fleetnetv1alpha1.ServiceExportValid))
 	expectedValidCond := &metav1.Condition{
 		Type:               string(fleetnetv1alpha1.ServiceExportValid),
 		Status:             metav1.ConditionFalse,
 		Reason:             svcExportInvalidIneligibleCondReason,
-		ObservedGeneration: svc.Generation,
+		ObservedGeneration: svcExport.Generation,
 		Message:            fmt.Sprintf("service %s/%s is not eligible for export", svcExport.Namespace, svcExport.Name),
 	}
 	if condition.EqualCondition(validCond, expectedValidCond) {
@@ -520,13 +520,13 @@ func (r *Reconciler) addServiceExportCleanupFinalizer(ctx context.Context, svcEx
 
 // markServiceExportAsValid marks a ServiceExport as valid; if no conflict condition has been added, the
 // ServiceExport will be marked as pending conflict resolution as well.
-func (r *Reconciler) markServiceExportAsValid(ctx context.Context, svcExport *fleetnetv1alpha1.ServiceExport, svc *corev1.Service) error {
+func (r *Reconciler) markServiceExportAsValid(ctx context.Context, svcExport *fleetnetv1alpha1.ServiceExport) error {
 	validCond := meta.FindStatusCondition(svcExport.Status.Conditions, string(fleetnetv1alpha1.ServiceExportValid))
 	expectedValidCond := &metav1.Condition{
 		Type:               string(fleetnetv1alpha1.ServiceExportValid),
 		Status:             metav1.ConditionTrue,
 		Reason:             svcExportValidCondReason,
-		ObservedGeneration: svc.Generation,
+		ObservedGeneration: svcExport.Generation,
 		Message:            fmt.Sprintf("service %s/%s is valid for export", svcExport.Namespace, svcExport.Name),
 	}
 	conflictCond := meta.FindStatusCondition(svcExport.Status.Conditions, string(fleetnetv1alpha1.ServiceExportConflict))
@@ -549,7 +549,7 @@ func (r *Reconciler) markServiceExportAsValid(ctx context.Context, svcExport *fl
 	meta.SetStatusCondition(&svcExport.Status.Conditions, metav1.Condition{
 		Type:               string(fleetnetv1alpha1.ServiceExportConflict),
 		Status:             metav1.ConditionUnknown,
-		ObservedGeneration: svc.Generation,
+		ObservedGeneration: svcExport.Generation,
 		Reason:             svcExportPendingConflictResolutionReason,
 		Message:            fmt.Sprintf("service %s/%s is pending export conflict resolution", svcExport.Namespace, svcExport.Name),
 	})

--- a/pkg/controllers/member/serviceexport/controller_integration_test.go
+++ b/pkg/controllers/member/serviceexport/controller_integration_test.go
@@ -180,7 +180,7 @@ var (
 			return fmt.Errorf("serviceExport finalizers, got %v, want empty list", svcExport.Finalizers)
 		}
 
-		expectedCond := serviceExportInvalidNotFoundCondition(memberUserNS, svcName)
+		expectedCond := serviceExportInvalidNotFoundCondition(memberUserNS, svcName, svcExport.Generation)
 		validCond := meta.FindStatusCondition(svcExport.Status.Conditions, string(fleetnetv1alpha1.ServiceExportValid))
 		if diff := cmp.Diff(validCond, &expectedCond, ignoredCondFields); diff != "" {
 			return fmt.Errorf("serviceExportValid condition (-got, +want): %s", diff)
@@ -204,7 +204,7 @@ var (
 		if err := memberClient.Get(ctx, svcOrSvcExportKey, svc); err != nil {
 			return fmt.Errorf("service Get(%+v), got %w, want no error", svcOrSvcExportKey, err)
 		}
-		expectedCond := serviceExportInvalidIneligibleCondition(memberUserNS, svcName)
+		expectedCond := serviceExportInvalidIneligibleCondition(memberUserNS, svcName, svcExport.Generation)
 		validCond := meta.FindStatusCondition(svcExport.Status.Conditions, string(fleetnetv1alpha1.ServiceExportValid))
 		if diff := cmp.Diff(validCond, &expectedCond, ignoredCondFields); diff != "" {
 			return fmt.Errorf("serviceExportValid condition (-got, +want): %s", diff)
@@ -231,13 +231,13 @@ var (
 			return fmt.Errorf("serviceExport finalizers, got %v, want %v", svcExport.Finalizers, []string{svcExportCleanupFinalizer})
 		}
 
-		expectedValidCond := serviceExportValidCondition(memberUserNS, svcName)
+		expectedValidCond := serviceExportValidCondition(memberUserNS, svcName, svcExport.Generation)
 		validCond := meta.FindStatusCondition(svcExport.Status.Conditions, string(fleetnetv1alpha1.ServiceExportValid))
 		if diff := cmp.Diff(validCond, &expectedValidCond, ignoredCondFields); diff != "" {
 			return fmt.Errorf("serviceExportValid condition (-got, +want): %s", diff)
 		}
 
-		expectedConflictCond := serviceExportPendingConflictResolutionCondition(memberUserNS, svcName)
+		expectedConflictCond := serviceExportPendingConflictResolutionCondition(memberUserNS, svcName, svcExport.Generation)
 		conflictCond := meta.FindStatusCondition(svcExport.Status.Conditions, string(fleetnetv1alpha1.ServiceExportConflict))
 		if diff := cmp.Diff(conflictCond, &expectedConflictCond, ignoredCondFields); diff != "" {
 			return fmt.Errorf("serviceExportConflict condition (-got, +want): %s", diff)

--- a/test/e2e/export_service_test.go
+++ b/test/e2e/export_service_test.go
@@ -394,14 +394,16 @@ var _ = Describe("Test exporting service", func() {
 				}
 				wantedSvcExportConditions := []metav1.Condition{
 					{
-						Type:   string(fleetnetv1alpha1.ServiceExportValid),
-						Reason: "ServiceIsValid",
-						Status: metav1.ConditionTrue,
+						Type:               string(fleetnetv1alpha1.ServiceExportValid),
+						Reason:             "ServiceIsValid",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: svcExportObj.Generation,
 					},
 					{
-						Type:   string(fleetnetv1alpha1.ServiceExportConflict),
-						Reason: "ConflictFound",
-						Status: metav1.ConditionTrue,
+						Type:               string(fleetnetv1alpha1.ServiceExportConflict),
+						Reason:             "ConflictFound",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: svcExportObj.Generation,
 					},
 				}
 				return cmp.Diff(wantedSvcExportConditions, svcExportObj.Status.Conditions, framework.SvcExportConditionCmpOptions...)
@@ -456,14 +458,16 @@ var _ = Describe("Test exporting service", func() {
 				}
 				wantedSvcExportConditions := []metav1.Condition{
 					{
-						Type:   string(fleetnetv1alpha1.ServiceExportValid),
-						Reason: "ServiceIsValid",
-						Status: metav1.ConditionTrue,
+						Type:               string(fleetnetv1alpha1.ServiceExportValid),
+						Reason:             "ServiceIsValid",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: svcExportObj.Generation,
 					},
 					{
-						Type:   string(fleetnetv1alpha1.ServiceExportConflict),
-						Reason: "NoConflictFound",
-						Status: metav1.ConditionFalse,
+						Type:               string(fleetnetv1alpha1.ServiceExportConflict),
+						Reason:             "NoConflictFound",
+						Status:             metav1.ConditionFalse,
+						ObservedGeneration: svcExportObj.Generation,
 					},
 				}
 				return cmp.Diff(wantedSvcExportConditions, svcExportObj.Status.Conditions, framework.SvcExportConditionCmpOptions...)
@@ -487,14 +491,16 @@ var _ = Describe("Test exporting service", func() {
 				}
 				wantedSvcExportConditions := []metav1.Condition{
 					{
-						Type:   string(fleetnetv1alpha1.ServiceExportValid),
-						Reason: "ServiceIsValid",
-						Status: metav1.ConditionTrue,
+						Type:               string(fleetnetv1alpha1.ServiceExportValid),
+						Reason:             "ServiceIsValid",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: svcExportObj.Generation,
 					},
 					{
-						Type:   string(fleetnetv1alpha1.ServiceExportConflict),
-						Reason: "ConflictFound",
-						Status: metav1.ConditionTrue,
+						Type:               string(fleetnetv1alpha1.ServiceExportConflict),
+						Reason:             "ConflictFound",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: svcExportObj.Generation,
 					},
 				}
 				return cmp.Diff(wantedSvcExportConditions, svcExportObj.Status.Conditions, framework.SvcExportConditionCmpOptions...)
@@ -532,9 +538,10 @@ var _ = Describe("Test exporting service", func() {
 				}
 				wantedSvcExportConditions := []metav1.Condition{
 					{
-						Type:   string(fleetnetv1alpha1.ServiceExportValid),
-						Reason: "ServiceIneligible",
-						Status: metav1.ConditionFalse,
+						Type:               string(fleetnetv1alpha1.ServiceExportValid),
+						Reason:             "ServiceIneligible",
+						Status:             metav1.ConditionFalse,
+						ObservedGeneration: svcExportObj.Generation,
 					},
 				}
 				return cmp.Diff(wantedSvcExportConditions, svcExportObj.Status.Conditions, framework.SvcExportConditionCmpOptions...)
@@ -570,9 +577,10 @@ var _ = Describe("Test exporting service", func() {
 				}
 				wantedSvcExportConditions := []metav1.Condition{
 					{
-						Type:   string(fleetnetv1alpha1.ServiceExportValid),
-						Reason: "ServiceIneligible",
-						Status: metav1.ConditionFalse,
+						Type:               string(fleetnetv1alpha1.ServiceExportValid),
+						Reason:             "ServiceIneligible",
+						Status:             metav1.ConditionFalse,
+						ObservedGeneration: svcExportObj.Generation,
 					},
 				}
 				return cmp.Diff(wantedSvcExportConditions, svcExportObj.Status.Conditions, framework.SvcExportConditionCmpOptions...)

--- a/test/e2e/framework/consts.go
+++ b/test/e2e/framework/consts.go
@@ -31,7 +31,7 @@ const (
 var (
 	// SvcExportConditionCmpOptions configures comparison behaviors foo service export conditions.
 	SvcExportConditionCmpOptions = []cmp.Option{
-		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "ObservedGeneration", "Message"),
+		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "Message"),
 		cmpopts.SortSlices(func(condition1, condition2 metav1.Condition) bool { return condition1.Type < condition2.Type }),
 	}
 

--- a/test/e2e/framework/workload_manager.go
+++ b/test/e2e/framework/workload_manager.go
@@ -329,14 +329,16 @@ func (wm *WorkloadManager) ExportService(ctx context.Context, svcExport fleetnet
 			}
 			wantedSvcExportConditions := []metav1.Condition{
 				{
-					Type:   string(fleetnetv1alpha1.ServiceExportValid),
-					Reason: "ServiceIsValid",
-					Status: metav1.ConditionTrue,
+					Type:               string(fleetnetv1alpha1.ServiceExportValid),
+					Reason:             "ServiceIsValid",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: svcExportObj.Generation,
 				},
 				{
-					Type:   string(fleetnetv1alpha1.ServiceExportConflict),
-					Reason: "NoConflictFound",
-					Status: metav1.ConditionFalse,
+					Type:               string(fleetnetv1alpha1.ServiceExportConflict),
+					Reason:             "NoConflictFound",
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: svcExportObj.Generation,
 				},
 			}
 			svcExportConditionCmpRlt := cmp.Diff(wantedSvcExportConditions, svcExportObj.Status.Conditions, SvcExportConditionCmpOptions...)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
use the serviceExport generation instead of service
Note: service does not have the generation.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] run `make reviewable` for basic local test
- [ ] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

e2e tests passed, https://github.com/Azure/fleet-networking/actions/runs/13986059012

### Special notes for your reviewer
The change should not break the mcs or atm, and they're using serviceImport instead of serviceExport.
