### PR TITLE
fix: bump go version to 1.23.6 for CVE

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -17,7 +17,7 @@ env:
   # `public` indicates images to MCR wil be publicly available, and will be removed in the final MCR images
   REGISTRY_REPO: public/aks/fleet
 
-  GO_VERSION: '1.23.1'
+  GO_VERSION: '1.23.6'
 
 jobs:
   prepare-variables:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.23.1'
+  GO_VERSION: '1.23.6'
 
 jobs:
   detect-noop:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.23.1'
+  GO_VERSION: '1.23.6'
 
 jobs:
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -19,7 +19,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_VERSION: latest
 
-  GO_VERSION: '1.23.1'
+  GO_VERSION: '1.23.6'
 
 jobs:
   export-registry:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,7 +18,7 @@ env:
   MEMBER_NET_CONTROLLER_MANAGER_IMAGE_NAME: member-net-controller-manager
   MCS_CONTROLLER_MANAGER_IMAGE_NAME: mcs-controller-manager
 
-  GO_VERSION: '1.23.1'
+  GO_VERSION: '1.23.6'
 
 jobs:
   export-registry:

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.23.1'
+  GO_VERSION: '1.23.6'
 
 jobs:
   detect-noop:

--- a/docker/hub-net-controller-manager.Dockerfile
+++ b/docker/hub-net-controller-manager.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.1 as builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.6 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docker/mcs-controller-manager.Dockerfile
+++ b/docker/mcs-controller-manager.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.1 as builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.6 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docker/member-net-controller-manager.Dockerfile
+++ b/docker/member-net-controller-manager.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.1 as builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.6 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.goms.io/fleet-networking
 
-go 1.23.1
+go 1.23.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing CVEs,

- CVE-2024-45336
- CVE-2024-45341
- CVE-2025-22866

**Requirements**:

- [X] run `make reviewable` for basic local test
- [X] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to be tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
