### PR TITLE
feat: populate resourceID for trafficManagerBackend

### DIFF
--- a/pkg/controllers/hub/trafficmanagerbackend/controller.go
+++ b/pkg/controllers/hub/trafficmanagerbackend/controller.go
@@ -558,11 +558,20 @@ func generateAzureTrafficManagerEndpoint(backend *fleetnetv1beta1.TrafficManager
 }
 
 func buildAcceptedEndpointStatus(endpoint *armtrafficmanager.Endpoint, desiredEndpoint desiredEndpoint) fleetnetv1beta1.TrafficManagerEndpointStatus {
+	resourceID := ""
+	if endpoint.ID == nil {
+		err := controller.NewUnexpectedBehaviorError(fmt.Errorf("got nil ID for Azure Traffic Manager endpoint"))
+		klog.ErrorS(err, "Unexpected value returned by the Azure Traffic Manager", "atmEndpointName", *endpoint.Name)
+	} else {
+		resourceID = *endpoint.ID
+	}
+
 	return fleetnetv1beta1.TrafficManagerEndpointStatus{
-		Name:   strings.ToLower(*endpoint.Name), // name is case-insensitive
-		Target: endpoint.Properties.Target,
-		Weight: endpoint.Properties.Weight, // the calculated weight
-		From:   &desiredEndpoint.FromCluster,
+		Name:       strings.ToLower(*endpoint.Name), // name is case-insensitive
+		Target:     endpoint.Properties.Target,
+		Weight:     endpoint.Properties.Weight, // the calculated weight
+		From:       &desiredEndpoint.FromCluster,
+		ResourceID: resourceID,
 	}
 }
 

--- a/pkg/controllers/hub/trafficmanagerbackend/controller_integration_test.go
+++ b/pkg/controllers/hub/trafficmanagerbackend/controller_integration_test.go
@@ -726,6 +726,7 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 		})
 
 		It("Validating trafficManagerBackend", func() {
+			atmEndpointName := fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[0])
 			want := fleetnetv1beta1.TrafficManagerBackend{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       backendName,
@@ -737,15 +738,16 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 					Conditions: buildFalseCondition(backend.Generation),
 					Endpoints: []fleetnetv1beta1.TrafficManagerEndpointStatus{
 						{
-							Name: fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[0]),
+							Name: atmEndpointName,
 							From: &fleetnetv1beta1.FromCluster{
 								ClusterStatus: fleetnetv1beta1.ClusterStatus{
 									Cluster: memberClusterNames[0],
 								},
 								Weight: ptr.To(int64(1)), // the original weight is default to 1
 							},
-							Weight: ptr.To(backendWeight), // populate the weight using atm endpoint
-							Target: ptr.To(fakeprovider.ValidEndpointTarget),
+							Weight:     ptr.To(backendWeight), // populate the weight using atm endpoint
+							Target:     ptr.To(fakeprovider.ValidEndpointTarget),
+							ResourceID: fmt.Sprintf(fakeprovider.EndpointResourceIDFormat, fakeprovider.DefaultSubscriptionID, fakeprovider.DefaultResourceGroupName, profileName, atmEndpointName),
 						},
 					},
 				},
@@ -785,6 +787,7 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 
 		It("Should reconcile the endpoint back after the provider server stops returning 403", func() {
 			fakeprovider.DisableEndpointForbiddenErr()
+			atmEndpointName := fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[6])
 			want := fleetnetv1beta1.TrafficManagerBackend{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       backendName,
@@ -796,15 +799,16 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 					Conditions: buildTrueCondition(backend.Generation),
 					Endpoints: []fleetnetv1beta1.TrafficManagerEndpointStatus{
 						{
-							Name: fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[6]),
+							Name: atmEndpointName,
 							From: &fleetnetv1beta1.FromCluster{
 								ClusterStatus: fleetnetv1beta1.ClusterStatus{
 									Cluster: memberClusterNames[6],
 								},
 								Weight: ptr.To(int64(1)), // the original weight is default to 1
 							},
-							Weight: ptr.To(backendWeight), // populate the weight using atm endpoint
-							Target: ptr.To(fakeprovider.ValidEndpointTarget),
+							Weight:     ptr.To(backendWeight), // populate the weight using atm endpoint
+							Target:     ptr.To(fakeprovider.ValidEndpointTarget),
+							ResourceID: fmt.Sprintf(fakeprovider.EndpointResourceIDFormat, fakeprovider.DefaultSubscriptionID, fakeprovider.DefaultResourceGroupName, profileName, atmEndpointName),
 						},
 					},
 				},
@@ -830,6 +834,10 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 		})
 
 		It("Validating trafficManagerBackend", func() {
+			atmEndpointNames := []string{
+				fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[0]),
+				fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[3]),
+			}
 			want := fleetnetv1beta1.TrafficManagerBackend{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       backendName,
@@ -841,26 +849,28 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 					Conditions: buildTrueCondition(backend.Generation),
 					Endpoints: []fleetnetv1beta1.TrafficManagerEndpointStatus{
 						{
-							Name: fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[0]),
+							Name: atmEndpointNames[0],
 							From: &fleetnetv1beta1.FromCluster{
 								ClusterStatus: fleetnetv1beta1.ClusterStatus{
 									Cluster: memberClusterNames[0],
 								},
 								Weight: ptr.To(int64(1)),
 							},
-							Weight: ptr.To(backendWeight / 2), // populate the weight using atm endpoint
-							Target: ptr.To(fakeprovider.ValidEndpointTarget),
+							Weight:     ptr.To(backendWeight / 2), // populate the weight using atm endpoint
+							Target:     ptr.To(fakeprovider.ValidEndpointTarget),
+							ResourceID: fmt.Sprintf(fakeprovider.EndpointResourceIDFormat, fakeprovider.DefaultSubscriptionID, fakeprovider.DefaultResourceGroupName, profileName, atmEndpointNames[0]),
 						},
 						{
-							Name: fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[3]),
+							Name: atmEndpointNames[1],
 							From: &fleetnetv1beta1.FromCluster{
 								ClusterStatus: fleetnetv1beta1.ClusterStatus{
 									Cluster: memberClusterNames[3],
 								},
 								Weight: ptr.To(int64(1)),
 							},
-							Weight: ptr.To(backendWeight / 2), // populate the weight using atm endpoint
-							Target: ptr.To(fakeprovider.ValidEndpointTarget),
+							Weight:     ptr.To(backendWeight / 2), // populate the weight using atm endpoint
+							Target:     ptr.To(fakeprovider.ValidEndpointTarget),
+							ResourceID: fmt.Sprintf(fakeprovider.EndpointResourceIDFormat, fakeprovider.DefaultSubscriptionID, fakeprovider.DefaultResourceGroupName, profileName, atmEndpointNames[1]),
 						},
 					},
 				},
@@ -877,6 +887,10 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 		})
 
 		It("Validating trafficManagerBackend", func() {
+			atmEndpointNames := []string{
+				fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[0]),
+				fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[3]),
+			}
 			want := fleetnetv1beta1.TrafficManagerBackend{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       backendName,
@@ -888,26 +902,28 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 					Conditions: buildTrueCondition(backend.Generation),
 					Endpoints: []fleetnetv1beta1.TrafficManagerEndpointStatus{
 						{
-							Name: fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[0]),
+							Name: atmEndpointNames[0],
 							From: &fleetnetv1beta1.FromCluster{
 								ClusterStatus: fleetnetv1beta1.ClusterStatus{
 									Cluster: memberClusterNames[0],
 								},
 								Weight: ptr.To(int64(2)),
 							},
-							Weight: ptr.To(int64(7)), // 2/3 of the 10
-							Target: ptr.To(fakeprovider.ValidEndpointTarget),
+							Weight:     ptr.To(int64(7)), // 2/3 of the 10
+							Target:     ptr.To(fakeprovider.ValidEndpointTarget),
+							ResourceID: fmt.Sprintf(fakeprovider.EndpointResourceIDFormat, fakeprovider.DefaultSubscriptionID, fakeprovider.DefaultResourceGroupName, profileName, atmEndpointNames[0]),
 						},
 						{
-							Name: fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[3]),
+							Name: atmEndpointNames[1],
 							From: &fleetnetv1beta1.FromCluster{
 								ClusterStatus: fleetnetv1beta1.ClusterStatus{
 									Cluster: memberClusterNames[3],
 								},
 								Weight: ptr.To(int64(1)),
 							},
-							Weight: ptr.To(int64(4)), // 1/3 of 10
-							Target: ptr.To(fakeprovider.ValidEndpointTarget),
+							Weight:     ptr.To(int64(4)), // 1/3 of 10
+							Target:     ptr.To(fakeprovider.ValidEndpointTarget),
+							ResourceID: fmt.Sprintf(fakeprovider.EndpointResourceIDFormat, fakeprovider.DefaultSubscriptionID, fakeprovider.DefaultResourceGroupName, profileName, atmEndpointNames[1]),
 						},
 					},
 				},
@@ -931,6 +947,7 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 		})
 
 		It("Validating trafficManagerBackend", func() {
+			atmEndpointName := fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[0])
 			want := fleetnetv1beta1.TrafficManagerBackend{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       backendName,
@@ -942,15 +959,16 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 					Conditions: buildFalseCondition(backend.Generation),
 					Endpoints: []fleetnetv1beta1.TrafficManagerEndpointStatus{
 						{
-							Name: fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[0]),
+							Name: atmEndpointName,
 							From: &fleetnetv1beta1.FromCluster{
 								ClusterStatus: fleetnetv1beta1.ClusterStatus{
 									Cluster: memberClusterNames[0],
 								},
 								Weight: ptr.To(int64(2)),
 							},
-							Weight: ptr.To(int64(7)), // 2/3 of the 10 as the weight is calculated before the endpoints are created
-							Target: ptr.To(fakeprovider.ValidEndpointTarget),
+							Weight:     ptr.To(int64(7)), // 2/3 of the 10 as the weight is calculated before the endpoints are created
+							Target:     ptr.To(fakeprovider.ValidEndpointTarget),
+							ResourceID: fmt.Sprintf(fakeprovider.EndpointResourceIDFormat, fakeprovider.DefaultSubscriptionID, fakeprovider.DefaultResourceGroupName, profileName, atmEndpointName),
 						},
 					},
 				},
@@ -1031,6 +1049,7 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 		})
 
 		It("Validating trafficManagerBackend", func() {
+			atmEndpointName := fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[0])
 			want := fleetnetv1beta1.TrafficManagerBackend{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       backendName,
@@ -1042,15 +1061,16 @@ var _ = Describe("Test TrafficManagerBackend Controller", func() {
 					Conditions: buildTrueCondition(backend.Generation),
 					Endpoints: []fleetnetv1beta1.TrafficManagerEndpointStatus{
 						{
-							Name: fmt.Sprintf(AzureResourceEndpointNameFormat, backendName+"#", serviceName, memberClusterNames[0]),
+							Name: atmEndpointName,
 							From: &fleetnetv1beta1.FromCluster{
 								ClusterStatus: fleetnetv1beta1.ClusterStatus{
 									Cluster: memberClusterNames[0],
 								},
 								Weight: ptr.To(int64(2)),
 							},
-							Weight: ptr.To(int64(10)), // only 1 endpoint
-							Target: ptr.To(fakeprovider.ValidEndpointTarget),
+							Weight:     ptr.To(int64(10)), // only 1 endpoint
+							Target:     ptr.To(fakeprovider.ValidEndpointTarget),
+							ResourceID: fmt.Sprintf(fakeprovider.EndpointResourceIDFormat, fakeprovider.DefaultSubscriptionID, fakeprovider.DefaultResourceGroupName, profileName, atmEndpointName),
 						},
 					},
 				},

--- a/test/common/trafficmanager/azureprovider/profile.go
+++ b/test/common/trafficmanager/azureprovider/profile.go
@@ -20,8 +20,8 @@ import (
 var (
 	cmpProfileOptions = cmp.Options{
 		cmpopts.IgnoreFields(armtrafficmanager.Profile{}, "ID", "Name", "Type"),
-		cmpopts.IgnoreFields(armtrafficmanager.MonitorConfig{}, "ProfileMonitorStatus"),                                                           // cannot predict the monitor status
-		cmpopts.IgnoreFields(armtrafficmanager.Endpoint{}, "ID"),                                                                                  // ignore the resource ID for now
+		cmpopts.IgnoreFields(armtrafficmanager.MonitorConfig{}, "ProfileMonitorStatus"), // cannot predict the monitor status
+		// cmpopts.IgnoreFields(armtrafficmanager.Endpoint{}, "ID") // now controller populates the ResourceID and we can validate this field
 		cmpopts.IgnoreFields(armtrafficmanager.EndpointProperties{}, "TargetResourceID", "EndpointLocation", "EndpointMonitorStatus", "Priority"), // cannot predict the status
 		cmpopts.SortSlices(func(e1, e2 *armtrafficmanager.Endpoint) bool {
 			return *e1.Name < *e2.Name

--- a/test/common/trafficmanager/azureprovider/profile.go
+++ b/test/common/trafficmanager/azureprovider/profile.go
@@ -20,8 +20,7 @@ import (
 var (
 	cmpProfileOptions = cmp.Options{
 		cmpopts.IgnoreFields(armtrafficmanager.Profile{}, "ID", "Name", "Type"),
-		cmpopts.IgnoreFields(armtrafficmanager.MonitorConfig{}, "ProfileMonitorStatus"), // cannot predict the monitor status
-		// cmpopts.IgnoreFields(armtrafficmanager.Endpoint{}, "ID") // now controller populates the ResourceID and we can validate this field
+		cmpopts.IgnoreFields(armtrafficmanager.MonitorConfig{}, "ProfileMonitorStatus"),                                                           // cannot predict the monitor status
 		cmpopts.IgnoreFields(armtrafficmanager.EndpointProperties{}, "TargetResourceID", "EndpointLocation", "EndpointMonitorStatus", "Priority"), // cannot predict the status
 		cmpopts.SortSlices(func(e1, e2 *armtrafficmanager.Endpoint) bool {
 			return *e1.Name < *e2.Name

--- a/test/common/trafficmanager/fakeprovider/endpoint.go
+++ b/test/common/trafficmanager/fakeprovider/endpoint.go
@@ -7,6 +7,7 @@ package fakeprovider
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -113,6 +114,7 @@ func EndpointCreateOrUpdate(_ context.Context, resourceGroupName string, profile
 					Target:           ptr.To(ValidEndpointTarget),
 				},
 				Type: ptr.To(string(azureTrafficManagerEndpointTypePrefix + armtrafficmanager.EndpointTypeAzureEndpoints)),
+				ID:   ptr.To(fmt.Sprintf(EndpointResourceIDFormat, DefaultSubscriptionID, resourceGroupName, profileName, endpointName)),
 			},
 		}
 		resp.SetResponse(http.StatusOK, endpointResp, nil)

--- a/test/common/trafficmanager/fakeprovider/profile.go
+++ b/test/common/trafficmanager/fakeprovider/profile.go
@@ -27,7 +27,8 @@ const (
 	DefaultSubscriptionID    = "default-subscription-id"
 	DefaultResourceGroupName = "default-resource-group-name"
 
-	ProfileResourceIDFormat = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/trafficManagerProfiles/%s"
+	ProfileResourceIDFormat  = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/trafficManagerProfiles/%s"
+	EndpointResourceIDFormat = ProfileResourceIDFormat + "/azureEndpoints/%s"
 
 	ValidProfileName                         = "valid-profile"
 	ValidProfileWithEndpointsName            = "valid-profile-with-endpoints"

--- a/test/common/trafficmanager/validator/backend.go
+++ b/test/common/trafficmanager/validator/backend.go
@@ -33,6 +33,8 @@ var (
 
 	cmpTrafficManagerBackendStatusByIgnoringEndpointName = cmp.Options{
 		cmpConditionOptions,
+		// Here we don't validate the endpoint name and resource id to be decoupled from the implementation.
+		// It will be validated separately by comparing the values with the ones in the Azure traffic manager profile.
 		cmpopts.IgnoreFields(fleetnetv1beta1.TrafficManagerEndpointStatus{}, "Name", "ResourceID"), // ignore the generated endpoint name
 		cmpopts.SortSlices(func(s1, s2 fleetnetv1beta1.TrafficManagerEndpointStatus) bool {
 			return s1.From.Cluster < s2.From.Cluster

--- a/test/common/trafficmanager/validator/backend.go
+++ b/test/common/trafficmanager/validator/backend.go
@@ -33,7 +33,7 @@ var (
 
 	cmpTrafficManagerBackendStatusByIgnoringEndpointName = cmp.Options{
 		cmpConditionOptions,
-		cmpopts.IgnoreFields(fleetnetv1beta1.TrafficManagerEndpointStatus{}, "Name"), // ignore the generated endpoint name
+		cmpopts.IgnoreFields(fleetnetv1beta1.TrafficManagerEndpointStatus{}, "Name", "ResourceID"), // ignore the generated endpoint name
 		cmpopts.SortSlices(func(s1, s2 fleetnetv1beta1.TrafficManagerEndpointStatus) bool {
 			return s1.From.Cluster < s2.From.Cluster
 		}),

--- a/test/e2e/traffic_manager_test.go
+++ b/test/e2e/traffic_manager_test.go
@@ -768,6 +768,7 @@ func buildDesiredATMProfile(profile fleetnetv1beta1.TrafficManagerProfile, endpo
 	}
 	for _, e := range endpoints {
 		res.Properties.Endpoints = append(res.Properties.Endpoints, &armtrafficmanager.Endpoint{
+			ID:   &e.ResourceID,
 			Name: ptr.To(e.Name),
 			Type: ptr.To("Microsoft.Network/trafficManagerProfiles/azureEndpoints"),
 			Properties: &armtrafficmanager.EndpointProperties{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

populate resourceID for trafficManagerBackend status

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] run `make reviewable` for basic local test
- [ ] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

e2e tests, https://github.com/Azure/fleet-networking/actions/runs/14377670818

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
