### PR TITLE
feat: add validation for timeoutInSeconds for MonitorConfig in TrafficManagerProfile

### DIFF
--- a/api/v1beta1/trafficmanagerprofile_types.go
+++ b/api/v1beta1/trafficmanagerprofile_types.go
@@ -57,6 +57,8 @@ type TrafficManagerProfileSpec struct {
 
 // MonitorConfig defines the endpoint monitoring settings of the Traffic Manager profile.
 // https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-monitoring
+// +kubebuilder:validation:XValidation:rule="!has(self.intervalInSeconds) || (has(self.intervalInSeconds) && self.intervalInSeconds == 30) ? (!has(self.timeoutInSeconds) || (self.timeoutInSeconds >= 5 && self.timeoutInSeconds <= 10)) : true",message="timeoutInSeconds must be between 5 and 10 when intervalInSeconds is 30"
+// +kubebuilder:validation:XValidation:rule="has(self.intervalInSeconds) && self.intervalInSeconds == 10 ? (!has(self.timeoutInSeconds) || (self.timeoutInSeconds >= 5 && self.timeoutInSeconds <= 9)) : true",message="timeoutInSeconds must be between 5 and 9 when intervalInSeconds is 10"
 type MonitorConfig struct {
 	// The monitor interval for endpoints in this profile. This is the interval at which Traffic Manager will check the health
 	// of each endpoint in this profile.

--- a/api/v1beta1/trafficmanagerprofile_types.go
+++ b/api/v1beta1/trafficmanagerprofile_types.go
@@ -57,7 +57,7 @@ type TrafficManagerProfileSpec struct {
 
 // MonitorConfig defines the endpoint monitoring settings of the Traffic Manager profile.
 // https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-monitoring
-// +kubebuilder:validation:XValidation:rule="!has(self.intervalInSeconds) || (has(self.intervalInSeconds) && self.intervalInSeconds == 30) ? (!has(self.timeoutInSeconds) || (self.timeoutInSeconds >= 5 && self.timeoutInSeconds <= 10)) : true",message="timeoutInSeconds must be between 5 and 10 when intervalInSeconds is 30"
+// +kubebuilder:validation:XValidation:rule="has(self.intervalInSeconds) && self.intervalInSeconds == 30 ? (!has(self.timeoutInSeconds) || (self.timeoutInSeconds >= 5 && self.timeoutInSeconds <= 10)) : true",message="timeoutInSeconds must be between 5 and 10 when intervalInSeconds is 30"
 // +kubebuilder:validation:XValidation:rule="has(self.intervalInSeconds) && self.intervalInSeconds == 10 ? (!has(self.timeoutInSeconds) || (self.timeoutInSeconds >= 5 && self.timeoutInSeconds <= 9)) : true",message="timeoutInSeconds must be between 5 and 9 when intervalInSeconds is 10"
 type MonitorConfig struct {
 	// The monitor interval for endpoints in this profile. This is the interval at which Traffic Manager will check the health

--- a/config/crd/bases/networking.fleet.azure.com_trafficmanagerprofiles.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_trafficmanagerprofiles.yaml
@@ -305,6 +305,18 @@ spec:
                     minimum: 0
                     type: integer
                 type: object
+                x-kubernetes-validations:
+                - message: timeoutInSeconds must be between 5 and 10 when intervalInSeconds
+                    is 30
+                  rule: '!has(self.intervalInSeconds) || (has(self.intervalInSeconds)
+                    && self.intervalInSeconds == 30) ? (!has(self.timeoutInSeconds)
+                    || (self.timeoutInSeconds >= 5 && self.timeoutInSeconds <= 10))
+                    : true'
+                - message: timeoutInSeconds must be between 5 and 9 when intervalInSeconds
+                    is 10
+                  rule: 'has(self.intervalInSeconds) && self.intervalInSeconds ==
+                    10 ? (!has(self.timeoutInSeconds) || (self.timeoutInSeconds >=
+                    5 && self.timeoutInSeconds <= 9)) : true'
               resourceGroup:
                 description: |-
                   The name of the resource group to contain the Azure Traffic Manager resource corresponding to this profile.

--- a/config/crd/bases/networking.fleet.azure.com_trafficmanagerprofiles.yaml
+++ b/config/crd/bases/networking.fleet.azure.com_trafficmanagerprofiles.yaml
@@ -308,10 +308,9 @@ spec:
                 x-kubernetes-validations:
                 - message: timeoutInSeconds must be between 5 and 10 when intervalInSeconds
                     is 30
-                  rule: '!has(self.intervalInSeconds) || (has(self.intervalInSeconds)
-                    && self.intervalInSeconds == 30) ? (!has(self.timeoutInSeconds)
-                    || (self.timeoutInSeconds >= 5 && self.timeoutInSeconds <= 10))
-                    : true'
+                  rule: 'has(self.intervalInSeconds) && self.intervalInSeconds ==
+                    30 ? (!has(self.timeoutInSeconds) || (self.timeoutInSeconds >=
+                    5 && self.timeoutInSeconds <= 10)) : true'
                 - message: timeoutInSeconds must be between 5 and 9 when intervalInSeconds
                     is 10
                   rule: 'has(self.intervalInSeconds) && self.intervalInSeconds ==

--- a/pkg/controllers/hub/trafficmanagerprofile/controller_integration_test.go
+++ b/pkg/controllers/hub/trafficmanagerprofile/controller_integration_test.go
@@ -154,14 +154,16 @@ var _ = Describe("Test TrafficManagerProfile Controller", func() {
 			validateTrafficManagerProfileMetricsEmitted(customRegistry, wantMetrics...)
 		})
 
-		It("Update the trafficManagerProfile spec", func() {
+		It("Update the trafficManagerProfile spec and should fail", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: name}, profile)).Should(Succeed(), "failed to get the trafficManagerProfile")
 			profile.Spec.MonitorConfig.IntervalInSeconds = ptr.To[int64](10)
 			profile.Spec.MonitorConfig.TimeoutInSeconds = ptr.To[int64](10)
-			Expect(k8sClient.Update(ctx, profile)).Should(Succeed(), "failed to update the trafficManagerProfile")
+			Expect(k8sClient.Update(ctx, profile)).ShouldNot(Succeed(), "failed to update the trafficManagerProfile")
 		})
 
-		It("Validating trafficManagerProfile status and update should fail", func() {
+		It("Validating trafficManagerProfile status and stay the same", func() {
+			profile.Spec.MonitorConfig.IntervalInSeconds = ptr.To[int64](30)
+			profile.Spec.MonitorConfig.TimeoutInSeconds = ptr.To[int64](10)
 			want := fleetnetv1beta1.TrafficManagerProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       name,
@@ -170,11 +172,13 @@ var _ = Describe("Test TrafficManagerProfile Controller", func() {
 				},
 				Spec: profile.Spec,
 				Status: fleetnetv1beta1.TrafficManagerProfileStatus{
+					DNSName:    ptr.To(fqdn),
+					ResourceID: profileResourceID,
 					Conditions: []metav1.Condition{
 						{
-							Status:             metav1.ConditionFalse,
+							Status:             metav1.ConditionTrue,
 							Type:               string(fleetnetv1beta1.TrafficManagerProfileConditionProgrammed),
-							Reason:             string(fleetnetv1beta1.TrafficManagerProfileReasonInvalid),
+							Reason:             string(fleetnetv1beta1.TrafficManagerProfileReasonProgrammed),
 							ObservedGeneration: profile.Generation,
 						},
 					},
@@ -183,7 +187,7 @@ var _ = Describe("Test TrafficManagerProfile Controller", func() {
 			validator.ValidateTrafficManagerProfile(ctx, k8sClient, &want, timeout)
 
 			By("By validating the status metrics")
-			wantMetrics = append(wantMetrics, generateMetrics(profile, want.Status.Conditions[0]))
+			// No new metric is emitted since thw profile failed to update
 			validateTrafficManagerProfileMetricsEmitted(customRegistry, wantMetrics...)
 		})
 

--- a/pkg/controllers/hub/trafficmanagerprofile/controller_integration_test.go
+++ b/pkg/controllers/hub/trafficmanagerprofile/controller_integration_test.go
@@ -161,9 +161,11 @@ var _ = Describe("Test TrafficManagerProfile Controller", func() {
 			Expect(k8sClient.Update(ctx, profile)).ShouldNot(Succeed(), "failed to update the trafficManagerProfile")
 		})
 
-		It("Validating trafficManagerProfile status and stay the same", func() {
+		It("Updating trafficManagerProfile spec to valid and validating trafficManagerProfile status", func() {
 			profile.Spec.MonitorConfig.IntervalInSeconds = ptr.To[int64](30)
 			profile.Spec.MonitorConfig.TimeoutInSeconds = ptr.To[int64](10)
+			Expect(k8sClient.Update(ctx, profile)).Should(Succeed(), "failed to update the trafficManagerProfile")
+
 			want := fleetnetv1beta1.TrafficManagerProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       name,
@@ -187,7 +189,7 @@ var _ = Describe("Test TrafficManagerProfile Controller", func() {
 			validator.ValidateTrafficManagerProfile(ctx, k8sClient, &want, timeout)
 
 			By("By validating the status metrics")
-			// No new metric is emitted since thw profile failed to update
+			// It overwrites the previous one as they have the same condition.
 			validateTrafficManagerProfileMetricsEmitted(customRegistry, wantMetrics...)
 		})
 

--- a/test/apis/v1beta1/api_validation_integration_test.go
+++ b/test/apis/v1beta1/api_validation_integration_test.go
@@ -193,6 +193,7 @@ var _ = Describe("Test networking v1alpha1 API validation", func() {
 			By("expecting denial of CREATE API with invalid timeoutInSeconds")
 			var err = hubClient.Create(ctx, profile)
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create API call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8serrors.StatusError{})))
+			Expect(statusErr.Status().Message).Should(ContainSubstring("spec.monitorConfig.timeoutInSeconds in body should be greater than or equal to 5"))
 			Expect(statusErr.Status().Message).Should(ContainSubstring("timeoutInSeconds must be between 5 and 10 when intervalInSeconds is 30"))
 		})
 
@@ -210,6 +211,7 @@ var _ = Describe("Test networking v1alpha1 API validation", func() {
 			By("expecting denial of CREATE API with invalid timeoutInSeconds")
 			var err = hubClient.Create(ctx, profile)
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create API call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8serrors.StatusError{})))
+			Expect(statusErr.Status().Message).Should(ContainSubstring("spec.monitorConfig.timeoutInSeconds in body should be less than or equal to 10"))
 			Expect(statusErr.Status().Message).Should(ContainSubstring("timeoutInSeconds must be between 5 and 10 when intervalInSeconds is 30"))
 		})
 
@@ -227,6 +229,7 @@ var _ = Describe("Test networking v1alpha1 API validation", func() {
 			By("expecting denial of CREATE API with invalid timeoutInSeconds")
 			var err = hubClient.Create(ctx, profile)
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create API call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8serrors.StatusError{})))
+			Expect(statusErr.Status().Message).Should(ContainSubstring("spec.monitorConfig.timeoutInSeconds in body should be greater than or equal to 5"))
 			Expect(statusErr.Status().Message).Should(ContainSubstring("timeoutInSeconds must be between 5 and 9 when intervalInSeconds is 10"))
 		})
 
@@ -244,10 +247,11 @@ var _ = Describe("Test networking v1alpha1 API validation", func() {
 			By("expecting denial of CREATE API with invalid timeoutInSeconds")
 			var err = hubClient.Create(ctx, profile)
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create API call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8serrors.StatusError{})))
+			Expect(statusErr.Status().Message).Should(ContainSubstring("spec.monitorConfig: Invalid value: \"object\": timeoutInSeconds must be between 5 and 9 when intervalInSeconds is 10"))
 			Expect(statusErr.Status().Message).Should(ContainSubstring("timeoutInSeconds must be between 5 and 9 when intervalInSeconds is 10"))
 		})
 
-		It("should deny creating API with timeoutInSeconds < 5 when timeoutInSeconds is not defined", func() {
+		It("should deny creating API with timeoutInSeconds < 5 when intervalInSeconds is not defined", func() {
 			profile := &fleetnetv1beta1.TrafficManagerProfile{
 				ObjectMeta: objectMetaWithNameValid,
 				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
@@ -260,10 +264,11 @@ var _ = Describe("Test networking v1alpha1 API validation", func() {
 			By("expecting denial of CREATE API with invalid timeoutInSeconds")
 			var err = hubClient.Create(ctx, profile)
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create API call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8serrors.StatusError{})))
+			Expect(statusErr.Status().Message).Should(ContainSubstring("spec.monitorConfig.timeoutInSeconds in body should be greater than or equal to 5"))
 			Expect(statusErr.Status().Message).Should(ContainSubstring("timeoutInSeconds must be between 5 and 10 when intervalInSeconds is 30"))
 		})
 
-		It("should deny creating API with timeoutInSeconds > 10 when timeoutInSeconds is not defined", func() {
+		It("should deny creating API with timeoutInSeconds > 10 when intervalInSeconds is not defined", func() {
 			profile := &fleetnetv1beta1.TrafficManagerProfile{
 				ObjectMeta: objectMetaWithNameValid,
 				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
@@ -276,6 +281,7 @@ var _ = Describe("Test networking v1alpha1 API validation", func() {
 			By("expecting denial of CREATE API with invalid timeoutInSeconds")
 			var err = hubClient.Create(ctx, profile)
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create API call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8serrors.StatusError{})))
+			Expect(statusErr.Status().Message).Should(ContainSubstring("spec.monitorConfig.timeoutInSeconds in body should be less than or equal to 10"))
 			Expect(statusErr.Status().Message).Should(ContainSubstring("timeoutInSeconds must be between 5 and 10 when intervalInSeconds is 30"))
 		})
 	})
@@ -391,7 +397,7 @@ var _ = Describe("Test networking v1alpha1 API validation", func() {
 			Expect(hubClient.Delete(ctx, profile)).Should(Succeed(), "failed to delete trafficManagerProfile")
 		})
 
-		It("should allow creating API with timeoutInSeconds at lower bound (5) when intervalInSeconds is 310", func() {
+		It("should allow creating API with timeoutInSeconds at lower bound (5) when intervalInSeconds is 10", func() {
 			profile := &fleetnetv1beta1.TrafficManagerProfile{
 				ObjectMeta: objectMetaWithNameValid,
 				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{

--- a/test/apis/v1beta1/api_validation_integration_test.go
+++ b/test/apis/v1beta1/api_validation_integration_test.go
@@ -248,7 +248,6 @@ var _ = Describe("Test networking v1alpha1 API validation", func() {
 			var err = hubClient.Create(ctx, profile)
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create API call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8serrors.StatusError{})))
 			Expect(statusErr.Status().Message).Should(ContainSubstring("spec.monitorConfig: Invalid value: \"object\": timeoutInSeconds must be between 5 and 9 when intervalInSeconds is 10"))
-			Expect(statusErr.Status().Message).Should(ContainSubstring("timeoutInSeconds must be between 5 and 9 when intervalInSeconds is 10"))
 		})
 
 		It("should deny creating API with timeoutInSeconds < 5 when intervalInSeconds is not defined", func() {

--- a/test/apis/v1beta1/api_validation_integration_test.go
+++ b/test/apis/v1beta1/api_validation_integration_test.go
@@ -179,6 +179,105 @@ var _ = Describe("Test networking v1alpha1 API validation", func() {
 			Expect(hubClient.Delete(ctx, profile)).Should(Succeed(), "failed to delete trafficManagerProfile")
 		})
 
+		It("should deny creating API with timeoutInSeconds < 5 when intervalInSeconds is 30", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						IntervalInSeconds: ptr.To(int64(30)),
+						TimeoutInSeconds:  ptr.To(int64(4)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			By("expecting denial of CREATE API with invalid timeoutInSeconds")
+			var err = hubClient.Create(ctx, profile)
+			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create API call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8serrors.StatusError{})))
+			Expect(statusErr.Status().Message).Should(ContainSubstring("timeoutInSeconds must be between 5 and 10 when intervalInSeconds is 30"))
+		})
+
+		It("should deny creating API with timeoutInSeconds > 10 when intervalInSeconds is 30", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						IntervalInSeconds: ptr.To(int64(30)),
+						TimeoutInSeconds:  ptr.To(int64(15)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			By("expecting denial of CREATE API with invalid timeoutInSeconds")
+			var err = hubClient.Create(ctx, profile)
+			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create API call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8serrors.StatusError{})))
+			Expect(statusErr.Status().Message).Should(ContainSubstring("timeoutInSeconds must be between 5 and 10 when intervalInSeconds is 30"))
+		})
+
+		It("should deny creating API with timeoutInSeconds < 5 when intervalInSeconds is 10", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						IntervalInSeconds: ptr.To(int64(10)),
+						TimeoutInSeconds:  ptr.To(int64(4)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			By("expecting denial of CREATE API with invalid timeoutInSeconds")
+			var err = hubClient.Create(ctx, profile)
+			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create API call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8serrors.StatusError{})))
+			Expect(statusErr.Status().Message).Should(ContainSubstring("timeoutInSeconds must be between 5 and 9 when intervalInSeconds is 10"))
+		})
+
+		It("should deny creating API with timeoutInSeconds > 9 when intervalInSeconds is 10", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						IntervalInSeconds: ptr.To(int64(10)),
+						TimeoutInSeconds:  ptr.To(int64(10)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			By("expecting denial of CREATE API with invalid timeoutInSeconds")
+			var err = hubClient.Create(ctx, profile)
+			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create API call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8serrors.StatusError{})))
+			Expect(statusErr.Status().Message).Should(ContainSubstring("timeoutInSeconds must be between 5 and 9 when intervalInSeconds is 10"))
+		})
+
+		It("should deny creating API with timeoutInSeconds < 5 when timeoutInSeconds is not defined", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						TimeoutInSeconds: ptr.To(int64(3)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			By("expecting denial of CREATE API with invalid timeoutInSeconds")
+			var err = hubClient.Create(ctx, profile)
+			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create API call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8serrors.StatusError{})))
+			Expect(statusErr.Status().Message).Should(ContainSubstring("timeoutInSeconds must be between 5 and 10 when intervalInSeconds is 30"))
+		})
+
+		It("should deny creating API with timeoutInSeconds > 10 when timeoutInSeconds is not defined", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						TimeoutInSeconds: ptr.To(int64(11)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			By("expecting denial of CREATE API with invalid timeoutInSeconds")
+			var err = hubClient.Create(ctx, profile)
+			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create API call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8serrors.StatusError{})))
+			Expect(statusErr.Status().Message).Should(ContainSubstring("timeoutInSeconds must be between 5 and 10 when intervalInSeconds is 30"))
+		})
 	})
 
 	Context("Test TrafficManagerProfile API validation - valid cases", func() {
@@ -230,6 +329,138 @@ var _ = Describe("Test networking v1alpha1 API validation", func() {
 			}
 			Expect(hubClient.Create(ctx, trafficManagerProfileName)).Should(Succeed(), "failed to create trafficManagerProfile")
 			Expect(hubClient.Delete(ctx, trafficManagerProfileName)).Should(Succeed(), "failed to delete trafficManagerProfile")
+		})
+
+		It("should allow creating API with valid timeoutInSeconds when intervalInSeconds is 30", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						IntervalInSeconds: ptr.To(int64(30)),
+						TimeoutInSeconds:  ptr.To(int64(7)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			Expect(hubClient.Create(ctx, profile)).Should(Succeed(), "failed to create trafficManagerProfile")
+			Expect(hubClient.Delete(ctx, profile)).Should(Succeed(), "failed to delete trafficManagerProfile")
+		})
+
+		It("should allow creating API with timeoutInSeconds at lower bound (5) when intervalInSeconds is 30", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						IntervalInSeconds: ptr.To(int64(30)),
+						TimeoutInSeconds:  ptr.To(int64(5)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			Expect(hubClient.Create(ctx, profile)).Should(Succeed(), "failed to create trafficManagerProfile at lower bound")
+			Expect(hubClient.Delete(ctx, profile)).Should(Succeed(), "failed to delete trafficManagerProfile at lower bound")
+		})
+
+		It("should allow creating API with timeoutInSeconds at upper bound (10) when intervalInSeconds is 30", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						IntervalInSeconds: ptr.To(int64(30)),
+						TimeoutInSeconds:  ptr.To(int64(10)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			Expect(hubClient.Create(ctx, profile)).Should(Succeed(), "failed to create trafficManagerProfile at upper bound")
+			Expect(hubClient.Delete(ctx, profile)).Should(Succeed(), "failed to delete trafficManagerProfile at upper bound")
+		})
+
+		It("should allow creating API with valid timeoutInSeconds when intervalInSeconds is 10", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						IntervalInSeconds: ptr.To(int64(10)),
+						TimeoutInSeconds:  ptr.To(int64(8)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			Expect(hubClient.Create(ctx, profile)).Should(Succeed(), "failed to create trafficManagerProfile")
+			Expect(hubClient.Delete(ctx, profile)).Should(Succeed(), "failed to delete trafficManagerProfile")
+		})
+
+		It("should allow creating API with timeoutInSeconds at lower bound (5) when intervalInSeconds is 310", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						IntervalInSeconds: ptr.To(int64(10)),
+						TimeoutInSeconds:  ptr.To(int64(5)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			Expect(hubClient.Create(ctx, profile)).Should(Succeed(), "failed to create trafficManagerProfile at lower bound")
+			Expect(hubClient.Delete(ctx, profile)).Should(Succeed(), "failed to delete trafficManagerProfile at lower bound")
+		})
+
+		It("should allow creating API with timeoutInSeconds at upper bound (9) when intervalInSeconds is 10", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						IntervalInSeconds: ptr.To(int64(30)),
+						TimeoutInSeconds:  ptr.To(int64(9)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			Expect(hubClient.Create(ctx, profile)).Should(Succeed(), "failed to create trafficManagerProfile at upper bound")
+			Expect(hubClient.Delete(ctx, profile)).Should(Succeed(), "failed to delete trafficManagerProfile at upper bound")
+		})
+
+		It("should allow creating API with valid timeoutInSeconds when intervalInSeconds is not defined", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						TimeoutInSeconds: ptr.To(int64(10)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			Expect(hubClient.Create(ctx, profile)).Should(Succeed(), "failed to create trafficManagerProfile")
+			Expect(hubClient.Delete(ctx, profile)).Should(Succeed(), "failed to delete trafficManagerProfile")
+		})
+
+		It("should allow creating API with timeoutInSeconds at lower bound (5) when intervalInSeconds is not defined", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						TimeoutInSeconds: ptr.To(int64(5)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			Expect(hubClient.Create(ctx, profile)).Should(Succeed(), "failed to create trafficManagerProfile at lower bound")
+			Expect(hubClient.Delete(ctx, profile)).Should(Succeed(), "failed to delete trafficManagerProfile at lower bound")
+		})
+
+		It("should allow creating API with timeoutInSeconds at upper bound (10) when intervalInSeconds is not defined", func() {
+			profile := &fleetnetv1beta1.TrafficManagerProfile{
+				ObjectMeta: objectMetaWithNameValid,
+				Spec: fleetnetv1beta1.TrafficManagerProfileSpec{
+					MonitorConfig: &fleetnetv1beta1.MonitorConfig{
+						TimeoutInSeconds: ptr.To(int64(10)),
+					},
+					ResourceGroup: "test-resource-group",
+				},
+			}
+			Expect(hubClient.Create(ctx, profile)).Should(Succeed(), "failed to create trafficManagerProfile at upper bound")
+			Expect(hubClient.Delete(ctx, profile)).Should(Succeed(), "failed to delete trafficManagerProfile at upper bound")
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind api-change


**What this PR does / why we need it**:
Uses CEL to add kubebuilder API validation for field timeoutInSeconds within MonitorConfig in TrafficManagerProfile.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] run `make reviewable` for basic local test
- [x] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests

### How has this code been tested
API validation integration test

### Special notes for your reviewer
If the IntervalInSeconds is set to 30 seconds (default), then you can set the Timeout value between 5 and 10 seconds.
If the IntervalInSeconds is set to 10 seconds, then you can set the Timeout value between 5 and 9 seconds.
As noted [here](https://github.com/Azure/fleet-networking/blob/1960b9dea70c4a658c1112ab9737a0b523829032/api/v1beta1/trafficmanagerprofile_types.go#L88C2-L91C78)
