### PR TITLE
fix: change the registry used to controller runtime for trafficeManagerProfile and trafficManagerBackend metrics

### DIFF
--- a/pkg/controllers/hub/trafficmanagerbackend/controller.go
+++ b/pkg/controllers/hub/trafficmanagerbackend/controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"go.goms.io/fleet/pkg/utils/condition"
@@ -45,8 +46,9 @@ import (
 )
 
 func init() {
-	// Register the custom metrics
-	prometheus.MustRegister(trafficManagerBackendStatusLastTimestampSeconds)
+	/// Register trafficManagerBackendStatusLastTimestampSeconds (fleet_networking_traffic_manager_backend_status_last_timestamp_seconds)
+	// metric with the controller runtime global metrics registry.
+	ctrlmetrics.MustRegister(trafficManagerBackendStatusLastTimestampSeconds)
 }
 
 const (

--- a/pkg/controllers/hub/trafficmanagerprofile/controller.go
+++ b/pkg/controllers/hub/trafficmanagerprofile/controller.go
@@ -25,6 +25,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"go.goms.io/fleet/pkg/utils/controller"
 
@@ -36,8 +37,9 @@ import (
 )
 
 func init() {
-	// Register the custom metrics
-	prometheus.MustRegister(trafficManagerProfileStatusLastTimestampSeconds)
+	/// Register trafficManagerProfileStatusLastTimestampSeconds (fleet_networking_traffic_manager_profile_status_last_timestamp_seconds)
+	// metric with the controller runtime global metrics registry.
+	ctrlmetrics.MustRegister(trafficManagerProfileStatusLastTimestampSeconds)
 }
 
 const (


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Change the metrics registry as we use controller runtime to emit metrics. Previously, with using the prometheus package nothing was being scraped.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] run `make reviewable` for basic local test
- [ ] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to be tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
