### PR TITLE
test: add the tests when public ip already exists in azure profile

### DIFF
--- a/docs/demos/TrafficManagerProfile/session-migrate-to-another-cluster/README.md
+++ b/docs/demos/TrafficManagerProfile/session-migrate-to-another-cluster/README.md
@@ -152,7 +152,7 @@ spec:
 ---
 
 ## Step 4: Clean Up Resources Using the `eviction` API
-- Remove the env label from the `aks-member-1` or add [a taint on the member](https://github.com/Azure/fleet/blob/main/docs/howtos/taint-toleration.md) so that the cluster won't be picked by the `clusterResourcePlacement` again.
+- Remove the env label from the `aks-member-1` or add [a taint on the member](https://kubefleet-dev.github.io/website/docs/how-tos/taints-tolerations/) so that the cluster won't be picked by the `clusterResourcePlacement` again.
 - Safely remove application workloads and services from `aks-member-1` once all traffic has shifted and all the client DNS caches are refreshed.
 
 > Note: test file located [here](../testfiles/placement-eviction-member-1.yaml).

--- a/docs/demos/TrafficManagerProfile/session-migrate-to-another-region/README.md
+++ b/docs/demos/TrafficManagerProfile/session-migrate-to-another-region/README.md
@@ -163,7 +163,7 @@ kubectl apply -f nginx-backend-uksouth.yaml
 > So that most of the traffic can be shifted to the new regions before deleting endpoints from eastus2euap region.
 
 ## Step 6: Cleanup & Finalization
-- Remove the env label from the `aks-member-1` & `aks-member-3` or add [a taint on these two members](https://github.com/Azure/fleet/blob/main/docs/howtos/taint-toleration.md) so that the cluster won't be picked by the `clusterResourcePlacement` again.
+- Remove the env label from the `aks-member-1` & `aks-member-3` or add [a taint on these two members](https://kubefleet-dev.github.io/website/docs/how-tos/taints-tolerations/) so that the cluster won't be picked by the `clusterResourcePlacement` again.
 - To ensure the application won't be disrupted, we can create the `ClusterResourcePlacementDisruptionBudget` for the protection.
 
 > Note: test file located [here](../testfiles/placement-disruption-budget.yaml).

--- a/docs/toubleshooting/DNSBasedGlobalLoadBalancing.md
+++ b/docs/toubleshooting/DNSBasedGlobalLoadBalancing.md
@@ -125,7 +125,26 @@ Common reasons and solutions for `TrafficManagerBackend` not being accepted:
    ```
 4. Not enough permissions to read the public IP address of the exported `Service` on the members.
    - Ensure fleet hub networking controller has been configured correctly to access public IP address of services on the members.
-5. [Reach the Azure Traffic Manager limits](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-traffic-manager-limits).
+5. The public IP address already exists in the Azure Traffic Manager profile.
+   - Please use the existing trafficManagerBackend to manage your endpoints exported by the service.
+   ```yaml
+   # sample status
+    status:
+    conditions:
+    - lastTransitionTime: "2025-05-16T08:43:33Z"
+      message: "2 endpoint(s) failed to be created/updated in the Azure Traffic Manager,
+        for example, PUT https://management.azure.com/subscriptions/c4528d9e-c99a-48bb-b12d-fde2176a43b8/resourceGroups/zhiyinglin-fleet-dev/providers/Microsoft.Network/trafficmanagerprofiles/fleet-5abc2041-c627-4937-ab04-ffd493975adb/AzureEndpoints/fleet-390eca1c-fdb2-49c8-bf28-3e4fc2660b08#hello-world-service#dev-member-2\n--------------------------------------------------------------------------------\nRESPONSE
+        400: 400 Bad Request\nERROR CODE: BadRequest\n--------------------------------------------------------------------------------\n{\n
+        \ \"error\": {\n    \"code\": \"BadRequest\",\n    \"message\": \"Endpoint
+        target must be unique in the profile. The following endpoint target already
+        exists: \\/subscriptions\\/c4528d9e-c99a-48bb-b12d-fde2176a43b8\\/resourceGroups\\/mc_zhiyinglin-fleet-dev_dev-member-2_eastus2\\/providers\\/Microsoft.Network\\/publicIPAddresses\\/kubernetes-ab5eea9ca3a6d44238cf82ef2e45b41a.\"\n
+        \ }\n}\n--------------------------------------------------------------------------------\n; "
+      observedGeneration: 1
+      reason: Invalid
+      status: "False"
+      type: Accepted
+   ```
+6. [Reach the Azure Traffic Manager limits](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-traffic-manager-limits).
     - 200 endpoints are allowed per profile. If the limit is reached, consider deleting unused endpoints or requesting an increase in the limit.
    
 Please check the `status` field of the `TrafficManagerBackend` or the `trafficmanagerbackend/controller.go` hub-net-controller-manager logs for more information.

--- a/docs/toubleshooting/DNSBasedGlobalLoadBalancing.md
+++ b/docs/toubleshooting/DNSBasedGlobalLoadBalancing.md
@@ -126,7 +126,8 @@ Common reasons and solutions for `TrafficManagerBackend` not being accepted:
 4. Not enough permissions to read the public IP address of the exported `Service` on the members.
    - Ensure fleet hub networking controller has been configured correctly to access public IP address of services on the members.
 5. The public IP address already exists in the Azure Traffic Manager profile.
-   - Please use the existing trafficManagerBackend to manage your endpoints exported by the service.
+   - Please use the existing trafficManagerBackend to manage your endpoints exported by the service. It happens that you've already added
+   endpoints to the profile by creating the trafficManagerBackend using the same service name and profile name.
    ```yaml
    # sample status
     status:


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:

Adding a webhook can blocking cx to create a duplicate trafficManagerBackend, which involves more work considering there's no validation webhook today. 

For now, we keep the implementation as it's today, and let the controller retry.
There is another rare case that customer will manually add the endpoint to the azure profile. In this case, the trafficManagerBackend will be unaccepted too.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] run `make reviewable` for basic local test
- [ ] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

added e2e tests, https://github.com/Azure/fleet-networking/actions/runs/15068110856

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
