### PR TITLE
fix: skip the reconcile when spec does not change

### DIFF
--- a/pkg/controllers/hub/trafficmanagerbackend/controller.go
+++ b/pkg/controllers/hub/trafficmanagerbackend/controller.go
@@ -28,10 +28,12 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"go.goms.io/fleet/pkg/utils/condition"
@@ -767,7 +769,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, dis
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&fleetnetv1beta1.TrafficManagerBackend{}).
+		For(&fleetnetv1beta1.TrafficManagerBackend{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			&fleetnetv1beta1.TrafficManagerProfile{},
 			handler.EnqueueRequestsFromMapFunc(r.trafficManagerProfileEventHandler()),

--- a/pkg/controllers/hub/trafficmanagerprofile/controller.go
+++ b/pkg/controllers/hub/trafficmanagerprofile/controller.go
@@ -27,9 +27,11 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"go.goms.io/fleet/pkg/utils/controller"
 
@@ -491,6 +493,6 @@ func emitTrafficManagerProfileStatusMetric(profile *fleetnetv1beta1.TrafficManag
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&fleetnetv1beta1.TrafficManagerProfile{}).
+		For(&fleetnetv1beta1.TrafficManagerProfile{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Improve the controller performance by skipping the reconcile when spec does not change

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] run `make reviewable` for basic local test
- [ ] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to be tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
