### PR TITLE
ci: Enable arm64 native support changes

### DIFF
--- a/docker/hub-net-controller-manager.Dockerfile
+++ b/docker/hub-net-controller-manager.Dockerfile
@@ -1,6 +1,9 @@
 # Build the hub-net-controller-manager binary
 FROM mcr.microsoft.com/oss/go/microsoft/golang:1.24.6 as builder
 
+ARG GOOS=linux
+ARG GOARCH=amd64
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -15,9 +18,8 @@ COPY api/ api/
 COPY pkg/ pkg/
 
 # Build with CGO enabled and GOEXPERIMENT=systemcrypto for internal usage
-ARG TARGETOS
-ARG TARGETARCH
-RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o hub-net-controller-manager main.go
+RUN echo "Building images with GOOS=$GOOS GOARCH=$GOARCH"
+RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o hub-net-controller-manager main.go
 
 # Use Azure Linux distroless base image to package hub-net-controller-manager binary
 # Refer to https://mcr.microsoft.com/en-us/artifact/mar/azurelinux/distroless/base/about for more details

--- a/docker/mcs-controller-manager.Dockerfile
+++ b/docker/mcs-controller-manager.Dockerfile
@@ -1,6 +1,9 @@
 # Build the mcs-controller-manager binary
 FROM mcr.microsoft.com/oss/go/microsoft/golang:1.24.6 as builder
 
+ARG GOOS=linux
+ARG GOARCH=amd64
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -15,9 +18,8 @@ COPY api/ api/
 COPY pkg/ pkg/
 
 # Build with CGO enabled and GOEXPERIMENT=systemcrypto for internal usage
-ARG TARGETOS
-ARG TARGETARCH
-RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o mcs-controller-manager main.go
+RUN echo "Building images with GOOS=$GOOS GOARCH=$GOARCH"
+RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o mcs-controller-manager main.go
 
 # Use Azure Linux distroless base image to package mcs-controller-manager binary
 # Refer to https://mcr.microsoft.com/en-us/artifact/mar/azurelinux/distroless/base/about for more details

--- a/docker/member-net-controller-manager.Dockerfile
+++ b/docker/member-net-controller-manager.Dockerfile
@@ -1,6 +1,9 @@
 # Build the member-net-controller-manager binary
 FROM mcr.microsoft.com/oss/go/microsoft/golang:1.24.6 as builder
 
+ARG GOOS=linux
+ARG GOARCH=amd64
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -15,9 +18,8 @@ COPY api/ api/
 COPY pkg/ pkg/
 
 # Build with CGO enabled and GOEXPERIMENT=systemcrypto for internal usage
-ARG TARGETOS
-ARG TARGETARCH
-RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o member-net-controller-manager main.go
+RUN echo "Building images with GOOS=$GOOS GOARCH=$GOARCH"
+RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o member-net-controller-manager main.go
 
 # Use Azure Linux distroless base image to package member-net-controller-manager binary
 # Refer to https://mcr.microsoft.com/en-us/artifact/mar/azurelinux/distroless/base/about for more details

--- a/docker/net-crd-installer.Dockerfile
+++ b/docker/net-crd-installer.Dockerfile
@@ -1,6 +1,9 @@
 # Build the net-crd-installer binary
 FROM mcr.microsoft.com/oss/go/microsoft/golang:1.24.6 AS builder
 
+ARG GOOS=linux
+ARG GOARCH=amd64
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -12,10 +15,9 @@ RUN go mod download
 # Copy the go source
 COPY cmd/net-crd-installer/ cmd/net-crd-installer/
 
-ARG TARGETARCH
-
 # Build with CGO enabled and GOEXPERIMENT=systemcrypto for internal usage
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=${TARGETARCH} GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o net-crd-installer cmd/net-crd-installer/main.go
+RUN echo "Building images with GOOS=linux GOARCH=$GOARCH"
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o net-crd-installer cmd/net-crd-installer/main.go
 
 # Use Azure Linux distroless base image to package net-crd-installer binary
 # Refer to https://mcr.microsoft.com/en-us/artifact/mar/azurelinux/distroless/base/about for more details


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR updates the Dockerfiles and Makefile to enable building native ARM64 images on supported platforms. The E2E tests will use the native images if applicable.

**Requirements**:

- [x] run `make reviewable` for basic local test
- [x] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [ ] includes documentation
- [ ] adds unit tests

### How has this code been tested

### Special notes for your reviewer

Be sure to direct your reviewers' attention to anything that needs special consideration.

