### PR TITLE
feat: add support for building ARM64 images

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -68,6 +68,8 @@ jobs:
           MEMBER_NET_CONTROLLER_MANAGER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}-amd64
           MCS_CONTROLLER_MANAGER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}-amd64
           NET_CRD_INSTALLER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}-amd64
+          TARGET_ARCH: amd64
+          AUTO_DETECT_ARCH: "FALSE"
   
   publish-images-arm64:
     runs-on:

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -42,7 +42,7 @@ jobs:
           # NOTE(mainred): As exporting a variable from a secret is not possible, the shared variable registry obtained
           # from AZURE_REGISTRY secret is not exported from here.
 
-  publish-images:
+  publish-images-amd64:
     runs-on:
       labels: [ self-hosted, "1ES.Pool=1es-aks-fleet-networking-pool-ubuntu" ]
     needs: prepare-variables
@@ -64,3 +64,141 @@ jobs:
         env:
           TAG: ${{ needs.prepare-variables.outputs.release_tag }}
           REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
+          HUB_NET_CONTROLLER_MANAGER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}-amd64
+          MEMBER_NET_CONTROLLER_MANAGER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}-amd64
+          MCS_CONTROLLER_MANAGER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}-amd64
+          NET_CRD_INSTALLER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}-amd64
+  
+  publish-images-arm64:
+    runs-on:
+      labels: [ self-hosted, "1ES.Pool=1es-aks-fleet-networking-pool-ubuntu-arm64" ]
+    needs: prepare-variables
+    steps:
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-variables.outputs.release_tag }}
+      - name: 'Install the Azure CLI'
+        # Note (chenyu1): the self-hosted 1ES ARM64 pool, for some reason, does not have Azure CLI installed by default;
+        # install it manually here.
+        run:
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      - name: 'Set up build dependencies'
+        # Note (chenyu1): the self-hosted 1ES ARM64 pool, for some reason, does not have the common build
+        # tools (e.g., make) installed by default; install them manually.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential acl
+      - name: 'Set up Docker'
+        # Note (chenyu1): the self-hosted 1ES ARM64 pool, for some reason, does not have Docker installed by default,
+        # and cannot have Docker installed via the docker/setup-docker-action Github Action, hence the manual setup
+        # steps here.
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+      - name: 'Enable Docker access'
+        # Note (chenyu1): there are situations where the newgrp command will not take effect; set access
+        # to the docker daemon directly just in case.
+        run: |
+          sudo groupadd docker || true
+          echo "Adding $USER to the docker group"
+          sudo usermod -aG docker $USER
+          newgrp docker
+          sudo setfacl --modify user:$USER:rw /var/run/docker.sock 
+      - name: 'Login the ACR'
+        run: |
+          az login --identity 
+          az acr login -n ${{ secrets.AZURE_REGISTRY }}
+      - name: 'Verify Docker CLI'
+        run: |
+          docker version
+          docker info
+      - name: Build and publish controller manager images
+        run: |
+          make push
+        env:
+          TAG: ${{ needs.prepare-variables.outputs.release_tag }}
+          REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
+          HUB_NET_CONTROLLER_MANAGER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}-arm64
+          MEMBER_NET_CONTROLLER_MANAGER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}-arm64
+          MCS_CONTROLLER_MANAGER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}-arm64
+          NET_CRD_INSTALLER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}-arm64
+          TARGET_ARCH: arm64
+          AUTO_DETECT_ARCH: "FALSE"
+  
+  create-image-manifest-bundle:
+    runs-on:
+      # Use the x86_64 1ES pool to run this job; in theory it can be run on the ARM64 1ES pool as well.
+      labels: [self-hosted, "1ES.Pool=1es-aks-fleet-networking-pool-ubuntu"]
+    needs: [prepare-variables, publish-images-amd64, publish-images-arm64]
+    steps:
+    - name: 'Wait until images are processed'
+      # Note (chenyu1): as we are pulling from ACR rather than MCR, the images should be available almost
+      # immediately after the push is done; the delay is added here as a precaution.
+      run: |
+        echo "Waiting for 3 minutes to ensure that images are fully processed"
+        sleep 180
+    - name: 'Login the ACR'
+      run: |
+        az login --identity 
+        az acr login -n ${{ secrets.AZURE_REGISTRY }}
+    - name: 'Pull the hub networking agent images from ACR'
+      # Note (chenyu1): must set the target platform explictly.
+      run: |
+        docker pull --platform linux/amd64 ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/hub-net-controller-manager:${{ needs.prepare-variables.outputs.release_tag }}-amd64
+        docker pull --platform linux/arm64 ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/hub-net-controller-manager:${{ needs.prepare-variables.outputs.release_tag }}-arm64
+    - name: 'Create and push multi-arch image manifests for the hub networking agent image'
+      # Note (chenyu1): use `docker buildx imagetools create`, otherwise attestations cannot be perserved.
+      run: |
+        docker buildx imagetools create \
+          -t ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/hub-net-controller-manager:${{ needs.prepare-variables.outputs.release_tag }} \
+          ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/hub-net-controller-manager:${{ needs.prepare-variables.outputs.release_tag }}-amd64 \
+          ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/hub-net-controller-manager:${{ needs.prepare-variables.outputs.release_tag }}-arm64
+    - name: 'Pull the member networking agent images from ACR'
+      # Note (chenyu1): must set the target platform explictly.
+      run: |
+        docker pull --platform linux/amd64 ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/member-net-controller-manager:${{ needs.prepare-variables.outputs.release_tag }}-amd64
+        docker pull --platform linux/arm64 ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/member-net-controller-manager:${{ needs.prepare-variables.outputs.release_tag }}-arm64
+    - name: 'Create and push multi-arch image manifests for the member networking agent image'
+      # Note (chenyu1): use `docker buildx imagetools create`, otherwise attestations cannot be perserved.
+      run: |
+        docker buildx imagetools create \
+          -t ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/member-net-controller-manager:${{ needs.prepare-variables.outputs.release_tag }} \
+          ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/member-net-controller-manager:${{ needs.prepare-variables.outputs.release_tag }}-amd64 \
+          ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/member-net-controller-manager:${{ needs.prepare-variables.outputs.release_tag }}-arm64
+    - name: 'Pull the MCS agent images from ACR'
+      # Note (chenyu1): must set the target platform explictly.
+      run: |
+        docker pull --platform linux/amd64 ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/mcs-controller-manager:${{ needs.prepare-variables.outputs.release_tag }}-amd64
+        docker pull --platform linux/arm64 ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/mcs-controller-manager:${{ needs.prepare-variables.outputs.release_tag }}-arm64
+    - name: 'Create and push multi-arch image manifests for the MCS agent image'
+      # Note (chenyu1): use `docker buildx imagetools create`, otherwise attestations cannot be perserved.
+      run: |
+        docker buildx imagetools create \
+          -t ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/mcs-controller-manager:${{ needs.prepare-variables.outputs.release_tag }} \
+          ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/mcs-controller-manager:${{ needs.prepare-variables.outputs.release_tag }}-amd64 \
+          ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/mcs-controller-manager:${{ needs.prepare-variables.outputs.release_tag }}-arm64
+    - name: 'Pull the networking crd installer images from ACR'
+      # Note (chenyu1): must set the target platform explictly.
+      run: |
+        docker pull --platform linux/amd64 ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/net-crd-installer:${{ needs.prepare-variables.outputs.release_tag }}-amd64
+        docker pull --platform linux/arm64 ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/net-crd-installer:${{ needs.prepare-variables.outputs.release_tag }}-arm64
+    - name: 'Create and push multi-arch image manifests for the networking crd installer image'
+      # Note (chenyu1): use `docker buildx imagetools create`, otherwise attestations cannot be perserved.
+      run: |
+        docker buildx imagetools create \
+          -t ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/net-crd-installer:${{ needs.prepare-variables.outputs.release_tag }} \
+          ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/net-crd-installer:${{ needs.prepare-variables.outputs.release_tag }}-amd64 \
+          ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}/net-crd-installer:${{ needs.prepare-variables.outputs.release_tag }}-arm64


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR updates the GitHub Actions pipelines to allow building ARM64/multi-arch images.

**Which issue(s) this PR fixes**:

N/A

**Requirements**:

- [x] run `make reviewable` for basic local test
- [x] Read and followed fleet-networking's [Code of conduct](https://github.com/Azure/fleet-networking/blob/main/CODE_OF_CONDUCT.md).
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [N/A] includes documentation
- [N/A] adds unit tests

### How has this code been tested

N/A

### Special notes for your reviewer

N/A
