### PR TITLE
chore: Remove explicit `GOEXPERIMENT=systemcrypto`

### DIFF
--- a/docker/hub-net-controller-manager.Dockerfile
+++ b/docker/hub-net-controller-manager.Dockerfile
@@ -17,9 +17,9 @@ COPY cmd/hub-net-controller-manager/main.go main.go
 COPY api/ api/
 COPY pkg/ pkg/
 
-# Build with CGO enabled and GOEXPERIMENT=systemcrypto for internal usage
+# Build with CGO enabled for internal usage
 RUN echo "Building images with GOOS=$GOOS GOARCH=$GOARCH"
-RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o hub-net-controller-manager main.go
+RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GO111MODULE=on go build -o hub-net-controller-manager main.go
 
 # Use Azure Linux distroless base image to package hub-net-controller-manager binary
 # Refer to https://mcr.microsoft.com/en-us/artifact/mar/azurelinux/distroless/base/about for more details

--- a/docker/mcs-controller-manager.Dockerfile
+++ b/docker/mcs-controller-manager.Dockerfile
@@ -17,7 +17,7 @@ COPY cmd/mcs-controller-manager/main.go main.go
 COPY api/ api/
 COPY pkg/ pkg/
 
-# Build with CGO enabled and GOEXPERIMENT=systemcrypto for internal usage
+# Build with CGO enabled for internal usage
 RUN echo "Building images with GOOS=$GOOS GOARCH=$GOARCH"
 RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GO111MODULE=on go build -o mcs-controller-manager main.go
 

--- a/docker/mcs-controller-manager.Dockerfile
+++ b/docker/mcs-controller-manager.Dockerfile
@@ -19,7 +19,7 @@ COPY pkg/ pkg/
 
 # Build with CGO enabled and GOEXPERIMENT=systemcrypto for internal usage
 RUN echo "Building images with GOOS=$GOOS GOARCH=$GOARCH"
-RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o mcs-controller-manager main.go
+RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GO111MODULE=on go build -o mcs-controller-manager main.go
 
 # Use Azure Linux distroless base image to package mcs-controller-manager binary
 # Refer to https://mcr.microsoft.com/en-us/artifact/mar/azurelinux/distroless/base/about for more details

--- a/docker/member-net-controller-manager.Dockerfile
+++ b/docker/member-net-controller-manager.Dockerfile
@@ -17,9 +17,9 @@ COPY cmd/member-net-controller-manager/main.go main.go
 COPY api/ api/
 COPY pkg/ pkg/
 
-# Build with CGO enabled and GOEXPERIMENT=systemcrypto for internal usage
+# Build with CGO enabled for internal usage
 RUN echo "Building images with GOOS=$GOOS GOARCH=$GOARCH"
-RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o member-net-controller-manager main.go
+RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GO111MODULE=on go build -o member-net-controller-manager main.go
 
 # Use Azure Linux distroless base image to package member-net-controller-manager binary
 # Refer to https://mcr.microsoft.com/en-us/artifact/mar/azurelinux/distroless/base/about for more details

--- a/docker/net-crd-installer.Dockerfile
+++ b/docker/net-crd-installer.Dockerfile
@@ -15,9 +15,9 @@ RUN --mount=type=cache,target=/go/pkg/mod go mod download
 # Copy the go source
 COPY cmd/net-crd-installer/ cmd/net-crd-installer/
 
-# Build with CGO enabled and GOEXPERIMENT=systemcrypto for internal usage
+# Build with CGO enabled for internal usage
 RUN echo "Building images with GOOS=linux GOARCH=$GOARCH"
-RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=1 GOOS=linux GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o net-crd-installer cmd/net-crd-installer/main.go
+RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=1 GOOS=linux GOARCH=$GOARCH GO111MODULE=on go build -o net-crd-installer cmd/net-crd-installer/main.go
 
 # Use Azure Linux distroless base image to package net-crd-installer binary
 # Refer to https://mcr.microsoft.com/en-us/artifact/mar/azurelinux/distroless/base/about for more details


### PR DESCRIPTION
### Description of your changes

Microsoft build of Go maintainer here. SystemCrypto is enabled by default since Go 1.25, no need to set it manually (see [docs](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/MigrationGuide.md#enable-systemcrypto)). That experiment will most likely disappear in Go 1.27, so removing it now will safe you from a build error once upgrading to Go 1.27.