### PR TITLE
chore: bump Go versions to address security concerns

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -17,7 +17,7 @@ env:
   # `public` indicates images to MCR wil be publicly available, and will be removed in the final MCR images
   REGISTRY_REPO: public/aks/fleet
 
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   prepare-variables:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   detect-noop:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -19,7 +19,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_VERSION: latest
 
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   export-registry:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,7 +18,7 @@ env:
   MEMBER_NET_CONTROLLER_MANAGER_IMAGE_NAME: member-net-controller-manager
   MCS_CONTROLLER_MANAGER_IMAGE_NAME: mcs-controller-manager
 
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   export-registry:

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   detect-noop:

--- a/docker/hub-net-controller-manager.Dockerfile
+++ b/docker/hub-net-controller-manager.Dockerfile
@@ -1,5 +1,5 @@
 # Build the hub-net-controller-manager binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.11 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.12 AS builder
 
 ARG GOOS=linux
 ARG GOARCH=amd64

--- a/docker/mcs-controller-manager.Dockerfile
+++ b/docker/mcs-controller-manager.Dockerfile
@@ -1,5 +1,5 @@
 # Build the mcs-controller-manager binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.11 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.12 AS builder
 
 ARG GOOS=linux
 ARG GOARCH=amd64

--- a/docker/member-net-controller-manager.Dockerfile
+++ b/docker/member-net-controller-manager.Dockerfile
@@ -1,5 +1,5 @@
 # Build the member-net-controller-manager binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.11 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.12 AS builder
 
 ARG GOOS=linux
 ARG GOARCH=amd64

--- a/docker/net-crd-installer.Dockerfile
+++ b/docker/net-crd-installer.Dockerfile
@@ -1,5 +1,5 @@
 # Build the net-crd-installer binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.11 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.12 AS builder
 
 ARG GOOS=linux
 ARG GOARCH=amd64

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.goms.io/fleet-networking
 
-go 1.25.11
+go 1.25.12
 
 require go.goms.io/fleet v0.14.0
 


### PR DESCRIPTION
**What type of PR is this?**

This PR bumps Go versions (builder/`go.mod` to 1.25.12) to fix reported CVEs.

**What this PR does / why we need it**: security response

**Which issue(s) this PR fixes**:

NA

**Requirements**:

NA

### How has this code been tested

NA

### Special notes for your reviewer

NA