### PR TITLE
feat: run trivy daily at 6AM UTC and create Copilot issue for CVEs

### DIFF
--- a/.github/.copilot/breadcrumbs/2026-07-28-1709-trivy-workflow-auto-pr.md
+++ b/.github/.copilot/breadcrumbs/2026-07-28-1709-trivy-workflow-auto-pr.md
@@ -65,5 +65,5 @@
 ## References
 
 - Existing workflow: `.github/workflows/trivy.yml`
-- [Copilot coding agent docs](https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent)
+- [Copilot coding agent docs](https://docs.github.com/en/copilot/using-github-copilot/using-copilot-to-fix-issues)
 - [Trivy action](https://github.com/aquasecurity/trivy-action)

--- a/.github/.copilot/breadcrumbs/2026-07-28-1709-trivy-workflow-auto-pr.md
+++ b/.github/.copilot/breadcrumbs/2026-07-28-1709-trivy-workflow-auto-pr.md
@@ -65,5 +65,5 @@
 ## References
 
 - Existing workflow: `.github/workflows/trivy.yml`
-- [Copilot coding agent docs](https://docs.github.com/en/copilot/using-github-copilot/using-copilot-to-fix-issues)
+- Copilot coding agent: GitHub Copilot can be assigned to issues to automatically create fix PRs
 - [Trivy action](https://github.com/aquasecurity/trivy-action)

--- a/.github/.copilot/breadcrumbs/2026-07-28-1709-trivy-workflow-auto-pr.md
+++ b/.github/.copilot/breadcrumbs/2026-07-28-1709-trivy-workflow-auto-pr.md
@@ -1,0 +1,69 @@
+# Trivy Workflow Auto-PR via Copilot Agent
+
+## Requirements
+
+- Update the trivy workflow to run on a daily schedule at 6:00 AM UTC.
+- When CVEs are found, create a GitHub Issue assigned to Copilot coding agent.
+- Copilot coding agent will open a PR with the dependency fix.
+- Keep existing triggers (push to main, tag creation, manual dispatch).
+
+## Additional comments from user
+
+- Dependabot is not running frequently enough to catch CVEs in a timely manner.
+- Prefer Copilot coding agent to handle the remediation via an issue assignment.
+
+## Plan
+
+### Phase 1: Update Workflow Triggers
+- Task 1.1: Add `schedule` cron trigger for 6:00 AM UTC daily.
+
+### Phase 2: Add CVE Remediation Job
+- Task 2.1: Change trivy scan output to JSON format (in addition to table) to parse results.
+- Task 2.2: Add a step that parses trivy JSON output and creates a GitHub Issue assigned to Copilot.
+- Task 2.3: The issue body should include CVE IDs, affected packages, and severity so Copilot can act on it.
+- Task 2.4: Add `issues: write` permission for the workflow.
+
+### Checklist
+
+- [ ] Task 1.1: Add schedule cron trigger
+- [ ] Task 2.1: Change trivy output to JSON for parsing
+- [ ] Task 2.2: Add step to create GitHub Issue assigned to Copilot
+- [ ] Task 2.3: Issue body includes actionable CVE details
+- [ ] Task 2.4: Add issues:write permission
+
+### Success Criteria
+
+- Workflow runs daily at 6:00 AM UTC.
+- When HIGH/CRITICAL CVEs are found, a GitHub Issue is created and assigned to Copilot.
+- Existing push/tag/manual triggers continue to work (those still fail on CVEs without creating issues).
+
+## Decisions
+
+- Use JSON output from trivy to parse vulnerability details programmatically.
+- Only create issues on scheduled runs (not on push/tag) to avoid noise during development.
+- Assign issue to `copilot` user which triggers the Copilot coding agent.
+
+## Implementation Details
+
+- Added `schedule` trigger with cron `0 6 * * *` (daily 6 AM UTC).
+- Added `issues: write` permission.
+- Changed trivy output from `table` with `exit-code: 1` to `json` with file output.
+- Added `check-vulns` step that parses JSON to detect any vulnerabilities.
+- On non-scheduled runs: fails the build with a table summary (same behavior as before).
+- On scheduled runs: builds a markdown issue body with a CVE table and creates a GitHub Issue assigned to `copilot`.
+- Deduplication: checks if an issue with today's title already exists before creating.
+
+## Changes Made
+
+- `.github/workflows/trivy.yml` — Added schedule trigger, JSON output, vuln check logic, and Copilot issue creation.
+
+## Before/After Comparison
+
+**Before:** Workflow ran on push/tag/manual, output table format, failed build on CVEs.
+**After:** Additionally runs daily at 6 AM UTC. On scheduled runs, creates a GitHub Issue assigned to Copilot with CVE details so it can open a fix PR automatically.
+
+## References
+
+- Existing workflow: `.github/workflows/trivy.yml`
+- [Copilot coding agent docs](https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent)
+- [Trivy action](https://github.com/aquasecurity/trivy-action)

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,5 +1,7 @@
 name: Trivy Vulnerability Scanner
 on:
+  schedule:
+    - cron: '0 6 * * *' # Daily at 6:00 AM UTC
   push:
     branches:
       - main
@@ -11,6 +13,7 @@ on:
 permissions:
   contents: read
   packages: write
+  issues: write
 
 env:
   REGISTRY: ghcr.io
@@ -67,8 +70,8 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.HUB_NET_CONTROLLER_MANAGER_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
-          format: 'table'
-          exit-code: '1'
+          format: 'json'
+          output: 'trivy-hub-net.json'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
@@ -76,15 +79,14 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db 
-
+          TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db
 
       - name: Scan ${{ env.REGISTRY }}/${{ env.MEMBER_NET_CONTROLLER_MANAGER_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.MEMBER_NET_CONTROLLER_MANAGER_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
-          format: 'table'
-          exit-code: '1'
+          format: 'json'
+          output: 'trivy-member-net.json'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
@@ -92,14 +94,14 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db 
+          TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db
 
       - name: Scan ${{ env.REGISTRY }}/${{ env.MCS_CONTROLLER_MANAGER_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.MCS_CONTROLLER_MANAGER_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
-          format: 'table'
-          exit-code: '1'
+          format: 'json'
+          output: 'trivy-mcs.json'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
@@ -107,4 +109,93 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db 
+          TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db
+
+      - name: Check for vulnerabilities
+        id: check-vulns
+        run: |
+          has_vulns=false
+          for file in trivy-hub-net.json trivy-member-net.json trivy-mcs.json; do
+            count=$(jq '[.Results[]? | .Vulnerabilities[]?] | length' "$file")
+            if [ "$count" -gt 0 ]; then
+              has_vulns=true
+              break
+            fi
+          done
+          echo "has_vulns=$has_vulns" >> "$GITHUB_OUTPUT"
+
+      - name: Fail on vulnerabilities (non-scheduled runs)
+        if: steps.check-vulns.outputs.has_vulns == 'true' && github.event_name != 'schedule'
+        run: |
+          echo "::error::Vulnerabilities found. See trivy scan output."
+          for file in trivy-hub-net.json trivy-member-net.json trivy-mcs.json; do
+            echo "--- $file ---"
+            jq -r '.Results[]? | .Vulnerabilities[]? | "\(.VulnerabilityID) \(.Severity) \(.PkgName) \(.InstalledVersion) -> \(.FixedVersion)"' "$file"
+          done
+          exit 1
+
+      - name: Build vulnerability summary
+        if: steps.check-vulns.outputs.has_vulns == 'true' && github.event_name == 'schedule'
+        id: vuln-summary
+        run: |
+          {
+            echo 'body<<EOF'
+            echo "## Trivy CVE Scan - $(date -u +%Y-%m-%d)"
+            echo ""
+            echo "The daily vulnerability scan found **HIGH/CRITICAL** CVEs in our container images."
+            echo "Please update the affected Go dependencies in \`go.mod\` to the fixed versions listed below,"
+            echo "then run \`go mod tidy\` and verify the build passes with \`make build\`."
+            echo ""
+            echo "### Vulnerabilities"
+            echo ""
+            echo "| CVE | Severity | Package | Installed | Fixed | Image |"
+            echo "|-----|----------|---------|-----------|-------|-------|"
+            for file in trivy-hub-net.json trivy-member-net.json trivy-mcs.json; do
+              image=$(echo "$file" | sed 's/trivy-//;s/.json//')
+              jq -r --arg img "$image" \
+                '.Results[]? | .Vulnerabilities[]? | "| \(.VulnerabilityID) | \(.Severity) | \(.PkgName) | \(.InstalledVersion) | \(.FixedVersion) | \($img) |"' \
+                "$file"
+            done | sort -u
+            echo ""
+            echo "### Instructions"
+            echo ""
+            echo "1. For each Go library CVE, run: \`go get <package>@<fixed_version>\`"
+            echo "2. Run \`go mod tidy\` to clean up dependencies."
+            echo "3. Run \`make build\` to verify the build passes."
+            echo "4. Run \`make test\` to verify tests pass."
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create issue for Copilot
+        if: steps.check-vulns.outputs.has_vulns == 'true' && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const today = new Date().toISOString().split('T')[0];
+            const title = `fix: address trivy CVEs found on ${today}`;
+
+            // Check if an open issue already exists for today
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security,trivy',
+              per_page: 10
+            });
+            const alreadyExists = existing.data.some(i => i.title === title);
+            if (alreadyExists) {
+              console.log('Issue already exists for today, skipping.');
+              return;
+            }
+
+            const body = process.env.ISSUE_BODY;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: title,
+              body: body,
+              labels: ['security', 'trivy'],
+              assignees: ['copilot']
+            });
+        env:
+          ISSUE_BODY: ${{ steps.vuln-summary.outputs.body }}


### PR DESCRIPTION
## Summary

Updates the Trivy vulnerability scanner workflow to run on a daily schedule and automatically create GitHub Issues assigned to the Copilot coding agent when CVEs are found.

## Changes

- **Daily schedule**: Added cron trigger `0 6 * * *` (6:00 AM UTC) to catch overnight CVE disclosures.
- **JSON output**: Trivy now outputs JSON for programmatic parsing of vulnerability details.
- **Copilot auto-remediation**: On scheduled runs, if HIGH/CRITICAL CVEs are found, a GitHub Issue is created with a structured table of affected packages and fix versions, assigned to `copilot` to automatically open a fix PR.
- **Non-scheduled behavior preserved**: Push/tag/manual runs still fail the build on vulnerabilities (same as before).
- **Deduplication**: Checks for existing open issues with the same title before creating a new one.

## Prerequisites

- `security` and `trivy` labels must exist in the repository.
- Copilot coding agent must be enabled for this repository.

## Why

Dependabot doesn't run frequently enough to address CVEs in container images in a timely manner. This gives us a daily scan with automated fix PRs via Copilot.