### PR TITLE
fix: disable Flask debug mode in getting-started example (CWE-489)

### DIFF
--- a/examples/getting-started/app/main.py
+++ b/examples/getting-started/app/main.py
@@ -24,4 +24,4 @@ if __name__ == "__main__":
     except:
         pass
 
-    app.run(host="0.0.0.0", port=8080, debug=True)
+    app.run(host="0.0.0.0", port=8080)


### PR DESCRIPTION
## Summary
Fixes CWE-489 (Active Debug Code): the Flask `getting-started` example app was started with `debug=True`, enabling the Werkzeug interactive debugger. Since the example is deployed behind a `LoadBalancer` Service bound to `0.0.0.0`, this exposes the debugger console (and detailed error pages) to anonymous internet clients if deployed as documented, allowing potential remote code execution via Werkzeug PIN bypass.

## Change
Removed `debug=True` from `app.run(...)` in `examples/getting-started/app/main.py`.

## Fixes
Fixes #390
