### PR TITLE
fix: prevent script injection via workflow_dispatch releaseTag input (CWE-78)

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -30,14 +30,16 @@ jobs:
           fetch-depth: 0
       - name: 'Set output variables'
         id: vars
+        env:
+          RELEASE_TAG_INPUT: ${{ inputs.releaseTag }}
         run: |
           # set the image version
-          RELEASE_TAG=${{ inputs.releaseTag }}
+          RELEASE_TAG="$RELEASE_TAG_INPUT"
           if [ -z "$RELEASE_TAG" ]; then
             RELEASE_TAG=`git describe --tags $(git rev-list --tags --max-count=1)`
             echo "The user input release tag is empty, will use the latest tag $RELEASE_TAG."
           fi
-          echo "::set-output name=release_tag::$RELEASE_TAG"
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
 
           # NOTE(mainred): As exporting a variable from a secret is not possible, the shared variable registry obtained
           # from AZURE_REGISTRY secret is not exported from here.


### PR DESCRIPTION
## Summary
Fixes CWE-78 (OS Command Injection / GitHub Actions script injection): the `releaseTag` `workflow_dispatch` input was interpolated unquoted directly into a bash `run:` block via `${{ inputs.releaseTag }}`. GitHub Actions substitutes `${{ }}` expressions textually into the script *before* the shell parses it, so a crafted `releaseTag` value (e.g. `x"; curl ... | bash; #`) could break out of the assignment and run arbitrary commands with the release job's Azure managed identity permissions (used later to `az login --identity` and push images to ACR/MCR).

## Change
- Pass `inputs.releaseTag` through an `env:` mapping (`RELEASE_TAG_INPUT`) instead of interpolating it directly into the script body.
- Reference it as a quoted shell variable: `RELEASE_TAG="$RELEASE_TAG_INPUT"`.
- Replaced the deprecated `::set-output` command with `$GITHUB_OUTPUT` as a drive-by cleanup since the line was already being touched.

## Fixes
Fixes #391
